### PR TITLE
ci(vuke): add crates.io publish workflow

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Publish to crates.io
         run: cargo publish


### PR DESCRIPTION
## Summary
Adds automated publishing to crates.io when a new version tag is pushed.

Closes #5

## Changes
- New workflow `.github/workflows/crates.yml`
- Triggers on `v*` tags (consistent with AUR workflow)
- Requires `CARGO_REGISTRY_TOKEN` secret

## Testing
Workflow syntax validated. Will test on next release.

---
Co-Authored-By: Aei <aei@oad.earth>