### PR TITLE
feat(gpu): add wgpu-based acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,21 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
@@ -169,9 +193,24 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -187,6 +226,26 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cast"
@@ -297,6 +356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "codspeed"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,8 +448,18 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -388,6 +467,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -461,6 +551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +570,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -493,6 +598,39 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "generic-array"
@@ -528,10 +666,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.10.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.10.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "half"
@@ -543,6 +764,21 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -578,6 +814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,7 +840,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -611,6 +853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,7 +871,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -656,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +922,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -678,16 +953,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -715,12 +1024,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.10.0",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.17",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -770,6 +1125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,10 +1152,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -822,10 +1230,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro2"
@@ -835,6 +1255,12 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "quote"
@@ -876,6 +1302,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1331,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -925,12 +1372,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -957,6 +1416,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
@@ -1048,10 +1513,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
@@ -1068,6 +1557,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1097,6 +1608,55 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1193,9 +1753,21 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1221,6 +1793,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "bytemuck",
  "chrono",
  "clap",
  "codspeed-criterion-compat",
@@ -1229,6 +1802,7 @@ dependencies = [
  "indicatif",
  "md-5",
  "num-bigint",
+ "pollster",
  "rand_mt",
  "rayon",
  "secp256k1",
@@ -1236,6 +1810,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "wgpu",
 ]
 
 [[package]]
@@ -1274,6 +1849,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1329,6 +1917,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.10.0",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "cfg_aliases",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.17",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.10.0",
+ "block",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.10.0",
+ "js-sys",
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,16 +2035,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1355,6 +2086,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1380,11 +2122,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1483,6 +2244,12 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/oritwoen/vuke"
 keywords = ["bitcoin", "security", "research", "brainwallet", "vulnerability"]
 categories = ["cryptography", "command-line-utilities"]
 
+[features]
+default = []
+gpu = ["wgpu", "pollster", "bytemuck"]
+
 [dependencies]
 # Core
 anyhow = "1.0"
@@ -28,6 +32,11 @@ secp256k1 = { version = "0.29", features = ["global-context"] }
 bitcoin = { version = "0.32", features = ["rand"] }
 rand_mt = "4.2"
 num-bigint = "0.4"
+
+# GPU acceleration (optional)
+wgpu = { version = "24", optional = true }
+pollster = { version = "0.4", optional = true }
+bytemuck = { version = "1.21", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -91,7 +91,7 @@ pub trait Analyzer: Send + Sync {
     fn name(&self) -> &'static str;
 
     /// Analyze a key and return the result.
-    /// 
+    ///
     /// Progress bar is optional - used for long-running analyses like Milksad brute-force.
     fn analyze(&self, key: &[u8; 32], config: &AnalysisConfig, progress: Option<&ProgressBar>) -> AnalysisResult;
 
@@ -103,6 +103,26 @@ pub trait Analyzer: Send + Sync {
     /// Whether this analyzer requires brute-force (slow)
     fn is_brute_force(&self) -> bool {
         false
+    }
+
+    /// Whether this analyzer supports GPU acceleration
+    #[cfg(feature = "gpu")]
+    fn supports_gpu(&self) -> bool {
+        false
+    }
+
+    /// Analyze a key using GPU acceleration
+    ///
+    /// Default implementation falls back to CPU.
+    #[cfg(feature = "gpu")]
+    fn analyze_gpu(
+        &self,
+        _ctx: &crate::gpu::GpuContext,
+        key: &[u8; 32],
+        config: &AnalysisConfig,
+        progress: Option<&ProgressBar>,
+    ) -> Result<AnalysisResult, crate::gpu::GpuError> {
+        Ok(self.analyze(key, config, progress))
     }
 }
 

--- a/src/gpu/buffer.rs
+++ b/src/gpu/buffer.rs
@@ -1,0 +1,127 @@
+//! GPU buffer management.
+
+use super::context::GpuContext;
+use std::sync::Arc;
+
+/// Buffer factory for GPU memory allocation.
+/// Note: This creates new buffers on each call. For high-frequency usage,
+/// consider implementing actual buffer pooling with reuse.
+pub struct GpuBufferFactory {
+    device: Arc<wgpu::Device>,
+}
+
+impl GpuBufferFactory {
+    /// Create a new buffer factory.
+    pub fn new(ctx: &GpuContext) -> Self {
+        Self {
+            device: ctx.device.clone(),
+        }
+    }
+
+    /// Create a storage buffer for compute shader input.
+    pub fn create_storage_buffer(&self, label: &str, size: u64) -> wgpu::Buffer {
+        self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// Create a storage buffer with initial data.
+    pub fn create_storage_buffer_init(&self, label: &str, data: &[u8]) -> wgpu::Buffer {
+        use wgpu::util::DeviceExt;
+        self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some(label),
+            contents: data,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        })
+    }
+
+    /// Create a buffer for reading results back to CPU.
+    pub fn create_read_buffer(&self, label: &str, size: u64) -> wgpu::Buffer {
+        self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// Create a staging buffer for downloading data from GPU.
+    pub fn create_staging_buffer(&self, label: &str, size: u64) -> wgpu::Buffer {
+        self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// Create a uniform buffer for small, frequently-updated data.
+    pub fn create_uniform_buffer(&self, label: &str, size: u64) -> wgpu::Buffer {
+        self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// Create a uniform buffer with initial data.
+    pub fn create_uniform_buffer_init(&self, label: &str, data: &[u8]) -> wgpu::Buffer {
+        use wgpu::util::DeviceExt;
+        self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some(label),
+            contents: data,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        })
+    }
+}
+
+/// Helper to read data back from GPU buffer.
+pub async fn read_buffer(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    buffer: &wgpu::Buffer,
+    size: u64,
+) -> Vec<u8> {
+    let staging = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("staging-read"),
+        size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("read-encoder"),
+    });
+    encoder.copy_buffer_to_buffer(buffer, 0, &staging, 0, size);
+    queue.submit(Some(encoder.finish()));
+
+    let slice = staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        tx.send(result).unwrap();
+    });
+
+    device.poll(wgpu::Maintain::Wait);
+    rx.recv().unwrap().unwrap();
+
+    let data = slice.get_mapped_range().to_vec();
+    staging.unmap();
+
+    data
+}
+
+/// Synchronous version of read_buffer.
+pub fn read_buffer_sync(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    buffer: &wgpu::Buffer,
+    size: u64,
+) -> Vec<u8> {
+    pollster::block_on(read_buffer(device, queue, buffer, size))
+}

--- a/src/gpu/context.rs
+++ b/src/gpu/context.rs
@@ -1,0 +1,106 @@
+//! GPU context management.
+
+use super::error::GpuError;
+use std::sync::Arc;
+
+/// GPU context holding device, queue, and adapter information.
+pub struct GpuContext {
+    pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
+    pub adapter_info: wgpu::AdapterInfo,
+}
+
+/// GPU capabilities and limits.
+#[derive(Debug, Clone)]
+pub struct GpuCapabilities {
+    pub max_workgroup_size_x: u32,
+    pub max_workgroup_size_y: u32,
+    pub max_workgroup_size_z: u32,
+    pub max_compute_invocations_per_workgroup: u32,
+    pub max_storage_buffer_binding_size: u32,
+    pub backend: wgpu::Backend,
+}
+
+impl GpuContext {
+    /// Create a new GPU context.
+    ///
+    /// This is async because wgpu adapter and device requests are async.
+    /// Use `pollster::block_on` to call from sync code.
+    pub async fn new() -> Result<Self, GpuError> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or(GpuError::NoAdapter)?;
+
+        let adapter_info = adapter.get_info();
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("vuke-gpu"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
+                    memory_hints: wgpu::MemoryHints::Performance,
+                },
+                None,
+            )
+            .await?;
+
+        Ok(Self {
+            device: Arc::new(device),
+            queue: Arc::new(queue),
+            adapter_info,
+        })
+    }
+
+    /// Create a new GPU context synchronously.
+    pub fn new_sync() -> Result<Self, GpuError> {
+        pollster::block_on(Self::new())
+    }
+
+    /// Check if a GPU is available without fully initializing.
+    pub fn is_available() -> bool {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .is_some()
+    }
+
+    /// Get GPU capabilities.
+    pub fn capabilities(&self) -> GpuCapabilities {
+        let limits = self.device.limits();
+
+        GpuCapabilities {
+            max_workgroup_size_x: limits.max_compute_workgroup_size_x,
+            max_workgroup_size_y: limits.max_compute_workgroup_size_y,
+            max_workgroup_size_z: limits.max_compute_workgroup_size_z,
+            max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup,
+            max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size,
+            backend: self.adapter_info.backend,
+        }
+    }
+
+    /// Get a human-readable description of the GPU.
+    pub fn description(&self) -> String {
+        format!(
+            "{} ({:?})",
+            self.adapter_info.name, self.adapter_info.backend
+        )
+    }
+}

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,0 +1,48 @@
+//! GPU error types.
+
+use std::fmt;
+
+/// Errors that can occur during GPU operations.
+#[derive(Debug)]
+pub enum GpuError {
+    /// No suitable GPU adapter found
+    NoAdapter,
+    /// Failed to request GPU device
+    DeviceRequest(wgpu::RequestDeviceError),
+    /// Shader compilation failed
+    ShaderCompilation(String),
+    /// Buffer operation failed
+    BufferOperation(String),
+    /// GPU computation timed out
+    Timeout,
+    /// Generic GPU error
+    Other(String),
+}
+
+impl fmt::Display for GpuError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GpuError::NoAdapter => write!(f, "No suitable GPU adapter found"),
+            GpuError::DeviceRequest(e) => write!(f, "Failed to request GPU device: {}", e),
+            GpuError::ShaderCompilation(msg) => write!(f, "Shader compilation failed: {}", msg),
+            GpuError::BufferOperation(msg) => write!(f, "Buffer operation failed: {}", msg),
+            GpuError::Timeout => write!(f, "GPU computation timed out"),
+            GpuError::Other(msg) => write!(f, "GPU error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for GpuError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            GpuError::DeviceRequest(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<wgpu::RequestDeviceError> for GpuError {
+    fn from(err: wgpu::RequestDeviceError) -> Self {
+        GpuError::DeviceRequest(err)
+    }
+}

--- a/src/gpu/hash.rs
+++ b/src/gpu/hash.rs
@@ -1,0 +1,538 @@
+//! GPU-accelerated hash transform pipelines.
+
+use super::{buffer::GpuBufferFactory, context::GpuContext, error::GpuError, shaders};
+use bytemuck::{Pod, Zeroable};
+use std::sync::Arc;
+
+/// Hash algorithm selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashAlgorithm {
+    Sha256,
+    DoubleSha256,
+    Md5,
+}
+
+/// Parameters passed to hash shaders.
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct HashParams {
+    input_count: u32,
+    input_stride: u32, // bytes per input (64 for single block)
+    _pad0: u32,
+    _pad1: u32,
+}
+
+/// GPU pipeline for batch hash computation.
+pub struct GpuHashPipeline {
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    sha256_pipeline: wgpu::ComputePipeline,
+    md5_pipeline: wgpu::ComputePipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    buffer_factory: GpuBufferFactory,
+}
+
+impl GpuHashPipeline {
+    /// Create a new hash GPU pipeline.
+    pub fn new(ctx: &GpuContext) -> Result<Self, GpuError> {
+        let sha256_shader = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("sha256-shader"),
+                source: wgpu::ShaderSource::Wgsl(shaders::SHA256_SHADER.into()),
+            });
+
+        let md5_shader = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("md5-shader"),
+                source: wgpu::ShaderSource::Wgsl(shaders::MD5_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            ctx.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("hash-bind-group-layout"),
+                    entries: &[
+                        // Params (uniform)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        // Inputs (storage, read-only)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        // Outputs (storage, read-write)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 2,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
+                });
+
+        let pipeline_layout =
+            ctx.device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("hash-pipeline-layout"),
+                    bind_group_layouts: &[&bind_group_layout],
+                    push_constant_ranges: &[],
+                });
+
+        let sha256_pipeline =
+            ctx.device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some("sha256-pipeline"),
+                    layout: Some(&pipeline_layout),
+                    module: &sha256_shader,
+                    entry_point: Some("main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
+
+        let md5_pipeline = ctx
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("md5-pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &md5_shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        Ok(Self {
+            device: ctx.device.clone(),
+            queue: ctx.queue.clone(),
+            sha256_pipeline,
+            md5_pipeline,
+            bind_group_layout,
+            buffer_factory: GpuBufferFactory::new(ctx),
+        })
+    }
+
+    /// Compute hashes for a batch of inputs.
+    ///
+    /// Inputs should be pre-padded to 64 bytes each (single SHA256/MD5 block).
+    /// Returns 32-byte hashes for each input.
+    pub fn compute_batch(
+        &self,
+        algorithm: HashAlgorithm,
+        inputs: &[u8],
+        input_count: u32,
+    ) -> Result<Vec<[u8; 32]>, GpuError> {
+        const BLOCK_SIZE: u32 = 64;
+        const WORKGROUP_SIZE: u32 = 256;
+
+        if inputs.len() != (input_count as usize * BLOCK_SIZE as usize) {
+            return Err(GpuError::BufferOperation(format!(
+                "Expected {} bytes, got {}",
+                input_count * BLOCK_SIZE,
+                inputs.len()
+            )));
+        }
+
+        // Create buffers
+        let params = HashParams {
+            input_count,
+            input_stride: BLOCK_SIZE,
+            _pad0: 0,
+            _pad1: 0,
+        };
+
+        let params_buffer = self
+            .buffer_factory
+            .create_uniform_buffer_init("hash-params", bytemuck::bytes_of(&params));
+
+        let input_buffer = self
+            .buffer_factory
+            .create_storage_buffer_init("hash-inputs", inputs);
+
+        let output_size = (input_count as u64) * 32;
+        let output_buffer = self.buffer_factory.create_read_buffer("hash-outputs", output_size);
+
+        // Create bind group
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("hash-bind-group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: params_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: input_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: output_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        // Select pipeline
+        let pipeline = match algorithm {
+            HashAlgorithm::Sha256 | HashAlgorithm::DoubleSha256 => &self.sha256_pipeline,
+            HashAlgorithm::Md5 => &self.md5_pipeline,
+        };
+
+        let workgroups = input_count.div_ceil(WORKGROUP_SIZE);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("hash-encoder"),
+            });
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("hash-pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+
+        // Read results
+        let output_data =
+            super::buffer::read_buffer_sync(&self.device, &self.queue, &output_buffer, output_size);
+
+        // For double SHA256, we need to hash again
+        let final_data = if algorithm == HashAlgorithm::DoubleSha256 {
+            self.compute_second_sha256(&output_data, input_count)?
+        } else {
+            output_data
+        };
+
+        // Convert to array of [u8; 32]
+        let mut results = Vec::with_capacity(input_count as usize);
+        for chunk in final_data.chunks_exact(32) {
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(chunk);
+            results.push(hash);
+        }
+
+        Ok(results)
+    }
+
+    /// Compute second round of SHA256 for double SHA256.
+    fn compute_second_sha256(
+        &self,
+        first_hashes: &[u8],
+        count: u32,
+    ) -> Result<Vec<u8>, GpuError> {
+        // Pad each 32-byte hash to 64 bytes for second SHA256
+        let mut padded = Vec::with_capacity(count as usize * 64);
+
+        for chunk in first_hashes.chunks_exact(32) {
+            // Copy hash
+            padded.extend_from_slice(chunk);
+            // Add padding: 0x80, zeros, length in bits (256 = 0x100)
+            padded.push(0x80);
+            padded.extend_from_slice(&[0u8; 23]); // Pad to 56 bytes
+            // Length in bits (256) as big-endian u64
+            padded.extend_from_slice(&[0, 0, 0, 0, 0, 0, 1, 0]);
+        }
+
+        let params = HashParams {
+            input_count: count,
+            input_stride: 64,
+            _pad0: 0,
+            _pad1: 0,
+        };
+
+        let params_buffer = self
+            .buffer_factory
+            .create_uniform_buffer_init("hash2-params", bytemuck::bytes_of(&params));
+
+        let input_buffer = self
+            .buffer_factory
+            .create_storage_buffer_init("hash2-inputs", &padded);
+
+        let output_size = (count as u64) * 32;
+        let output_buffer = self
+            .buffer_factory
+            .create_read_buffer("hash2-outputs", output_size);
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("hash2-bind-group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: params_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: input_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: output_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        const WORKGROUP_SIZE: u32 = 256;
+        let workgroups = count.div_ceil(WORKGROUP_SIZE);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("hash2-encoder"),
+            });
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("hash2-pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.sha256_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+
+        Ok(super::buffer::read_buffer_sync(
+            &self.device,
+            &self.queue,
+            &output_buffer,
+            output_size,
+        ))
+    }
+
+    /// Prepare input data for hashing.
+    ///
+    /// Pads the input to a single 64-byte SHA256/MD5 block.
+    /// Input must be <= 55 bytes (to fit length in single block).
+    ///
+    /// Returns `Err` if input is too long for single block.
+    pub fn pad_input_sha256(input: &[u8]) -> Result<[u8; 64], GpuError> {
+        if input.len() > 55 {
+            return Err(GpuError::BufferOperation(format!(
+                "Input too long for single block: {} bytes (max 55)",
+                input.len()
+            )));
+        }
+
+        let mut block = [0u8; 64];
+        block[..input.len()].copy_from_slice(input);
+        block[input.len()] = 0x80;
+
+        // Length in bits as big-endian u64
+        let bit_len = (input.len() as u64) * 8;
+        block[56..64].copy_from_slice(&bit_len.to_be_bytes());
+
+        Ok(block)
+    }
+
+    /// Prepare input data for MD5 hashing.
+    ///
+    /// Pads the input to a single 64-byte MD5 block.
+    /// Input must be <= 55 bytes (to fit length in single block).
+    ///
+    /// Returns `Err` if input is too long for single block.
+    pub fn pad_input_md5(input: &[u8]) -> Result<[u8; 64], GpuError> {
+        if input.len() > 55 {
+            return Err(GpuError::BufferOperation(format!(
+                "Input too long for single block: {} bytes (max 55)",
+                input.len()
+            )));
+        }
+
+        let mut block = [0u8; 64];
+        block[..input.len()].copy_from_slice(input);
+        block[input.len()] = 0x80;
+
+        // Length in bits as little-endian u64
+        let bit_len = (input.len() as u64) * 8;
+        block[56..64].copy_from_slice(&bit_len.to_le_bytes());
+
+        Ok(block)
+    }
+}
+
+/// Maximum input length for single-block GPU hashing.
+pub const MAX_SINGLE_BLOCK_INPUT_LEN: usize = 55;
+
+/// Result of GPU batch hash preparation.
+pub struct GpuBatchResult<'a> {
+    /// Hashes computed on GPU (one per short input).
+    pub hashes: Vec<[u8; 32]>,
+    /// Indices of inputs that were processed on GPU.
+    pub processed_indices: Vec<usize>,
+    /// Inputs that need CPU fallback (too long for single block).
+    pub cpu_fallback: Vec<&'a crate::transform::Input>,
+}
+
+impl GpuHashPipeline {
+    /// Process a batch of inputs, computing hashes on GPU where possible.
+    ///
+    /// Returns GPU results and inputs requiring CPU fallback.
+    /// This is a helper to reduce code duplication across transform implementations.
+    pub fn process_batch<'a>(
+        &self,
+        algorithm: HashAlgorithm,
+        inputs: &'a [crate::transform::Input],
+    ) -> Result<GpuBatchResult<'a>, GpuError> {
+        let mut short_inputs = Vec::new();
+        let mut processed_indices = Vec::new();
+        let mut cpu_fallback = Vec::new();
+
+        for (i, input) in inputs.iter().enumerate() {
+            if input.string_val.len() <= MAX_SINGLE_BLOCK_INPUT_LEN {
+                short_inputs.push(input);
+                processed_indices.push(i);
+            } else {
+                cpu_fallback.push(input);
+            }
+        }
+
+        if short_inputs.is_empty() {
+            return Ok(GpuBatchResult {
+                hashes: Vec::new(),
+                processed_indices: Vec::new(),
+                cpu_fallback: inputs.iter().collect(),
+            });
+        }
+
+        let pad_fn = match algorithm {
+            HashAlgorithm::Sha256 | HashAlgorithm::DoubleSha256 => Self::pad_input_sha256,
+            HashAlgorithm::Md5 => Self::pad_input_md5,
+        };
+
+        let mut padded_data = Vec::with_capacity(short_inputs.len() * 64);
+        for input in &short_inputs {
+            let block = pad_fn(input.string_val.as_bytes())?;
+            padded_data.extend_from_slice(&block);
+        }
+
+        let hashes = self.compute_batch(algorithm, &padded_data, short_inputs.len() as u32)?;
+
+        Ok(GpuBatchResult {
+            hashes,
+            processed_indices,
+            cpu_fallback,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Sha256, Digest};
+    use md5::Md5;
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_sha256_matches_cpu() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuHashPipeline::new(&ctx).expect("Failed to create pipeline");
+
+        let test_inputs: &[&[u8]] = &[b"hello", b"world", b"test", b"gpu acceleration"];
+
+        let mut padded_inputs = Vec::new();
+        let mut expected: Vec<[u8; 32]> = Vec::new();
+
+        for input in test_inputs {
+            padded_inputs.extend_from_slice(&GpuHashPipeline::pad_input_sha256(input).unwrap());
+            expected.push(Sha256::digest(input).into());
+        }
+
+        let gpu_results = pipeline
+            .compute_batch(HashAlgorithm::Sha256, &padded_inputs, test_inputs.len() as u32)
+            .expect("GPU compute failed");
+
+        assert_eq!(gpu_results.len(), expected.len());
+        for (i, (gpu, cpu)) in gpu_results.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(gpu, cpu, "SHA256 mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_md5_matches_cpu() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuHashPipeline::new(&ctx).expect("Failed to create pipeline");
+
+        let test_inputs: &[&[u8]] = &[b"hello", b"world", b"md5test"];
+
+        let mut padded_inputs = Vec::new();
+        let mut expected: Vec<[u8; 32]> = Vec::new();
+
+        for input in test_inputs {
+            padded_inputs.extend_from_slice(&GpuHashPipeline::pad_input_md5(input).unwrap());
+
+            let result = Md5::digest(input);
+            let mut hash = [0u8; 32];
+            hash[..16].copy_from_slice(&result);
+            hash[16..].copy_from_slice(&result);
+            expected.push(hash);
+        }
+
+        let gpu_results = pipeline
+            .compute_batch(HashAlgorithm::Md5, &padded_inputs, test_inputs.len() as u32)
+            .expect("GPU compute failed");
+
+        assert_eq!(gpu_results.len(), expected.len());
+        for (i, (gpu, cpu)) in gpu_results.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(gpu, cpu, "MD5 mismatch at index {}", i);
+        }
+    }
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_double_sha256() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuHashPipeline::new(&ctx).expect("Failed to create pipeline");
+
+        let input = b"double hash test";
+        let padded = GpuHashPipeline::pad_input_sha256(input).unwrap();
+
+        let first = Sha256::digest(input);
+        let expected: [u8; 32] = Sha256::digest(&first).into();
+
+        let gpu_results = pipeline
+            .compute_batch(HashAlgorithm::DoubleSha256, &padded, 1)
+            .expect("GPU compute failed");
+
+        assert_eq!(gpu_results.len(), 1);
+        assert_eq!(gpu_results[0], expected);
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,18 @@
+//! GPU acceleration module using wgpu.
+//!
+//! Provides GPU-accelerated implementations for:
+//! - MT19937 brute-force (milksad analyzer)
+//! - Hash transforms (SHA256, MD5)
+
+mod context;
+mod error;
+mod buffer;
+mod shaders;
+mod mt19937;
+pub mod hash;
+
+pub use context::GpuContext;
+pub use error::GpuError;
+pub use buffer::GpuBufferFactory;
+pub use mt19937::GpuMt19937Pipeline;
+pub use hash::{GpuHashPipeline, HashAlgorithm};

--- a/src/gpu/mt19937.rs
+++ b/src/gpu/mt19937.rs
@@ -1,0 +1,470 @@
+//! GPU-accelerated MT19937 brute-force pipeline.
+
+use super::{context::GpuContext, error::GpuError, shaders};
+use bytemuck::{Pod, Zeroable};
+use std::sync::Arc;
+
+/// Workgroup size for MT19937 shader.
+///
+/// IMPORTANT: This value MUST match `@workgroup_size(N)` in mt19937.wgsl.
+/// Using 128 for balance between occupancy and per-thread state (2496 bytes).
+const WORKGROUP_SIZE: u32 = 128;
+
+/// Parameters passed to the MT19937 shader.
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct Mt19937Params {
+    seed_start: u32,
+    seed_count: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+/// Double buffer set for pipelining
+struct BufferSet {
+    params: wgpu::Buffer,
+    result: wgpu::Buffer,
+    found: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+}
+
+/// GPU pipeline for MT19937 brute-force seed search.
+///
+/// Uses persistent buffers and double-buffering for optimal throughput.
+pub struct GpuMt19937Pipeline {
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    pipeline: wgpu::ComputePipeline,
+    #[allow(dead_code)] // Kept for potential dynamic bind group creation
+    bind_group_layout: wgpu::BindGroupLayout,
+    // Persistent target buffer (shared between buffer sets)
+    target_buffer: wgpu::Buffer,
+    // Double buffer sets for pipelining
+    buffer_sets: [BufferSet; 2],
+}
+
+/// Result of a GPU brute-force search.
+#[derive(Debug, Clone)]
+pub struct Mt19937SearchResult {
+    /// The seed that was found, if any.
+    pub found_seed: Option<u32>,
+    /// Number of seeds tested.
+    pub seeds_tested: u64,
+}
+
+impl GpuMt19937Pipeline {
+    /// Create a new MT19937 GPU pipeline with pre-allocated buffers.
+    pub fn new(ctx: &GpuContext) -> Result<Self, GpuError> {
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("mt19937-shader"),
+                source: wgpu::ShaderSource::Wgsl(shaders::MT19937_SHADER.into()),
+            });
+
+        let bind_group_layout =
+            ctx.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("mt19937-bind-group-layout"),
+                    entries: &[
+                        // Params (uniform)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        // Target key (storage, read-only)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        // Result seed (storage, read-write)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 2,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        // Found flag (storage, read-write)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 3,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                    ],
+                });
+
+        let pipeline_layout =
+            ctx.device
+                .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("mt19937-pipeline-layout"),
+                    bind_group_layouts: &[&bind_group_layout],
+                    push_constant_ranges: &[],
+                });
+
+        let pipeline = ctx
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("mt19937-pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+        // Create persistent target buffer (32 bytes = 8 u32s)
+        let target_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("mt19937-target"),
+            size: 32,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        // Create double buffer sets
+        let buffer_sets = std::array::from_fn(|i| {
+            let label_suffix = if i == 0 { "a" } else { "b" };
+
+            let params = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("mt19937-params-{}", label_suffix)),
+                size: std::mem::size_of::<Mt19937Params>() as u64,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let result = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("mt19937-result-{}", label_suffix)),
+                size: 4,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let found = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("mt19937-found-{}", label_suffix)),
+                size: 4,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(&format!("mt19937-bind-group-{}", label_suffix)),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: params.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: target_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: result.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: found.as_entire_binding(),
+                    },
+                ],
+            });
+
+            BufferSet {
+                params,
+                result,
+                found,
+                bind_group,
+            }
+        });
+
+        Ok(Self {
+            device: ctx.device.clone(),
+            queue: ctx.queue.clone(),
+            pipeline,
+            bind_group_layout,
+            target_buffer,
+            buffer_sets,
+        })
+    }
+
+    /// Set the target key to search for.
+    fn set_target(&self, target_key: &[u8; 32]) {
+        // Convert to u32 array (little-endian, matching rand_mt)
+        let target_u32: [u32; 8] = [
+            u32::from_le_bytes([target_key[0], target_key[1], target_key[2], target_key[3]]),
+            u32::from_le_bytes([target_key[4], target_key[5], target_key[6], target_key[7]]),
+            u32::from_le_bytes([target_key[8], target_key[9], target_key[10], target_key[11]]),
+            u32::from_le_bytes([target_key[12], target_key[13], target_key[14], target_key[15]]),
+            u32::from_le_bytes([target_key[16], target_key[17], target_key[18], target_key[19]]),
+            u32::from_le_bytes([target_key[20], target_key[21], target_key[22], target_key[23]]),
+            u32::from_le_bytes([target_key[24], target_key[25], target_key[26], target_key[27]]),
+            u32::from_le_bytes([target_key[28], target_key[29], target_key[30], target_key[31]]),
+        ];
+        self.queue
+            .write_buffer(&self.target_buffer, 0, bytemuck::cast_slice(&target_u32));
+    }
+
+    /// Submit a batch for execution using the specified buffer set.
+    fn submit_batch(&self, buffer_idx: usize, seed_start: u32, seed_count: u32) {
+        let set = &self.buffer_sets[buffer_idx];
+
+        // Update params
+        let params = Mt19937Params {
+            seed_start,
+            seed_count,
+            _pad0: 0,
+            _pad1: 0,
+        };
+        self.queue
+            .write_buffer(&set.params, 0, bytemuck::bytes_of(&params));
+
+        // Reset result and found
+        self.queue
+            .write_buffer(&set.result, 0, bytemuck::bytes_of(&0u32));
+        self.queue
+            .write_buffer(&set.found, 0, bytemuck::bytes_of(&0u32));
+
+        // Dispatch
+        let workgroups = seed_count.div_ceil(WORKGROUP_SIZE);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("mt19937-encoder"),
+            });
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("mt19937-pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &set.bind_group, &[]);
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+    }
+
+    /// Read results from a buffer set.
+    fn read_results(&self, buffer_idx: usize) -> Option<u32> {
+        let set = &self.buffer_sets[buffer_idx];
+
+        let found_data =
+            super::buffer::read_buffer_sync(&self.device, &self.queue, &set.found, 4);
+        let found: u32 = bytemuck::cast_slice(&found_data)[0];
+
+        if found != 0 {
+            let result_data =
+                super::buffer::read_buffer_sync(&self.device, &self.queue, &set.result, 4);
+            let seed: u32 = bytemuck::cast_slice(&result_data)[0];
+            Some(seed)
+        } else {
+            None
+        }
+    }
+
+    /// Search for a seed that produces the target key.
+    ///
+    /// This searches the range [seed_start, seed_start + seed_count).
+    /// Returns as soon as a match is found.
+    pub fn search(
+        &self,
+        target_key: &[u8; 32],
+        seed_start: u32,
+        seed_count: u32,
+    ) -> Result<Mt19937SearchResult, GpuError> {
+        self.set_target(target_key);
+        self.submit_batch(0, seed_start, seed_count);
+
+        let found_seed = self.read_results(0);
+
+        Ok(Mt19937SearchResult {
+            found_seed,
+            seeds_tested: seed_count as u64,
+        })
+    }
+
+    /// Search the entire 32-bit seed space in batches with double-buffering.
+    ///
+    /// Uses pipelining: while GPU processes batch N, CPU reads results from batch N-1.
+    /// Calls the progress callback with (seeds_tested, found_seed) periodically.
+    pub fn search_full<F>(
+        &self,
+        target_key: &[u8; 32],
+        batch_size: u32,
+        mut progress: F,
+    ) -> Result<Mt19937SearchResult, GpuError>
+    where
+        F: FnMut(u64, Option<u32>) -> bool,
+    {
+        self.set_target(target_key);
+
+        let total: u64 = u32::MAX as u64 + 1;
+        let mut seeds_tested: u64 = 0;
+        let mut current_start: u64 = 0;
+
+        // Submit first batch
+        if current_start < total {
+            let count = (total - current_start).min(batch_size as u64) as u32;
+            self.submit_batch(0, current_start as u32, count);
+            current_start += count as u64;
+        }
+
+        let mut active_buffer = 0usize;
+        let mut pending_count = batch_size;
+
+        while seeds_tested < total {
+            // Submit next batch to alternate buffer (if more work remains)
+            let next_buffer = 1 - active_buffer;
+            let mut next_count = 0u32;
+
+            if current_start < total {
+                next_count = (total - current_start).min(batch_size as u64) as u32;
+                self.submit_batch(next_buffer, current_start as u32, next_count);
+                current_start += next_count as u64;
+            }
+
+            // Read results from current batch
+            if let Some(seed) = self.read_results(active_buffer) {
+                seeds_tested += pending_count as u64;
+                progress(seeds_tested, Some(seed));
+                return Ok(Mt19937SearchResult {
+                    found_seed: Some(seed),
+                    seeds_tested,
+                });
+            }
+
+            seeds_tested += pending_count as u64;
+
+            // Progress callback
+            if !progress(seeds_tested, None) {
+                return Ok(Mt19937SearchResult {
+                    found_seed: None,
+                    seeds_tested,
+                });
+            }
+
+            // No more batches to process
+            if next_count == 0 {
+                break;
+            }
+
+            // Swap buffers
+            active_buffer = next_buffer;
+            pending_count = next_count;
+        }
+
+        Ok(Mt19937SearchResult {
+            found_seed: None,
+            seeds_tested,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_mt::Mt;
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_mt19937_finds_seed() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuMt19937Pipeline::new(&ctx).expect("Failed to create pipeline");
+
+        let seed = 12345u32;
+        let mut rng = Mt::new(seed);
+        let mut target_key = [0u8; 32];
+        rng.fill_bytes(&mut target_key);
+
+        let result = pipeline.search(&target_key, 12300, 100).expect("Search failed");
+        assert_eq!(result.found_seed, Some(seed));
+    }
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_mt19937_seed_zero() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuMt19937Pipeline::new(&ctx).expect("Failed to create pipeline");
+
+        let seed = 0u32;
+        let mut rng = Mt::new(seed);
+        let mut target_key = [0u8; 32];
+        rng.fill_bytes(&mut target_key);
+
+        let result = pipeline.search(&target_key, 0, 100).expect("Search failed");
+        assert_eq!(result.found_seed, Some(seed));
+    }
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_mt19937_not_found() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuMt19937Pipeline::new(&ctx).expect("Failed to create pipeline");
+        let target_key = [0xdeu8; 32];
+
+        let result = pipeline.search(&target_key, 0, 1000).expect("Search failed");
+        assert_eq!(result.found_seed, None);
+        assert_eq!(result.seeds_tested, 1000);
+    }
+
+    #[test]
+    #[ignore] // Requires GPU
+    fn test_gpu_mt19937_double_buffer() {
+        let ctx = match pollster::block_on(GpuContext::new()) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+
+        let pipeline = GpuMt19937Pipeline::new(&ctx).expect("Failed to create pipeline");
+
+        // Test with seed that requires multiple batches
+        let seed = 500_000u32;
+        let mut rng = Mt::new(seed);
+        let mut target_key = [0u8; 32];
+        rng.fill_bytes(&mut target_key);
+
+        let result = pipeline
+            .search_full(&target_key, 100_000, |_, _| true)
+            .expect("Search failed");
+
+        assert_eq!(result.found_seed, Some(seed));
+    }
+}

--- a/src/gpu/shaders/md5.wgsl
+++ b/src/gpu/shaders/md5.wgsl
@@ -1,0 +1,169 @@
+// MD5 hash compute shader
+//
+// Computes MD5 hashes for batches of pre-padded input blocks.
+// Each thread processes one input message.
+// Note: MD5 produces 16 bytes, which is duplicated to fill 32 bytes.
+
+// MD5 constants (sine-based)
+const K: array<u32, 64> = array<u32, 64>(
+    0xd76aa478u, 0xe8c7b756u, 0x242070dbu, 0xc1bdceeeu,
+    0xf57c0fafu, 0x4787c62au, 0xa8304613u, 0xfd469501u,
+    0x698098d8u, 0x8b44f7afu, 0xffff5bb1u, 0x895cd7beu,
+    0x6b901122u, 0xfd987193u, 0xa679438eu, 0x49b40821u,
+    0xf61e2562u, 0xc040b340u, 0x265e5a51u, 0xe9b6c7aau,
+    0xd62f105du, 0x02441453u, 0xd8a1e681u, 0xe7d3fbc8u,
+    0x21e1cde6u, 0xc33707d6u, 0xf4d50d87u, 0x455a14edu,
+    0xa9e3e905u, 0xfcefa3f8u, 0x676f02d9u, 0x8d2a4c8au,
+    0xfffa3942u, 0x8771f681u, 0x6d9d6122u, 0xfde5380cu,
+    0xa4beea44u, 0x4bdecfa9u, 0xf6bb4b60u, 0xbebfbc70u,
+    0x289b7ec6u, 0xeaa127fau, 0xd4ef3085u, 0x04881d05u,
+    0xd9d4d039u, 0xe6db99e5u, 0x1fa27cf8u, 0xc4ac5665u,
+    0xf4292244u, 0x432aff97u, 0xab9423a7u, 0xfc93a039u,
+    0x655b59c3u, 0x8f0ccc92u, 0xffeff47du, 0x85845dd1u,
+    0x6fa87e4fu, 0xfe2ce6e0u, 0xa3014314u, 0x4e0811a1u,
+    0xf7537e82u, 0xbd3af235u, 0x2ad7d2bbu, 0xeb86d391u,
+);
+
+// Shift amounts
+const S: array<u32, 64> = array<u32, 64>(
+    7u, 12u, 17u, 22u, 7u, 12u, 17u, 22u, 7u, 12u, 17u, 22u, 7u, 12u, 17u, 22u,
+    5u, 9u, 14u, 20u, 5u, 9u, 14u, 20u, 5u, 9u, 14u, 20u, 5u, 9u, 14u, 20u,
+    4u, 11u, 16u, 23u, 4u, 11u, 16u, 23u, 4u, 11u, 16u, 23u, 4u, 11u, 16u, 23u,
+    6u, 10u, 15u, 21u, 6u, 10u, 15u, 21u, 6u, 10u, 15u, 21u, 6u, 10u, 15u, 21u,
+);
+
+// Initial values
+const A0: u32 = 0x67452301u;
+const B0: u32 = 0xefcdab89u;
+const C0: u32 = 0x98badcfeu;
+const D0: u32 = 0x10325476u;
+
+struct Params {
+    input_count: u32,
+    input_stride: u32,  // bytes per input (padded block size)
+    _pad0: u32,
+    _pad1: u32,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> inputs: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputs: array<u32>;
+
+fn rotl(x: u32, n: u32) -> u32 {
+    return (x << n) | (x >> (32u - n));
+}
+
+fn f_func(x: u32, y: u32, z: u32) -> u32 {
+    return (x & y) | (~x & z);
+}
+
+fn g_func(x: u32, y: u32, z: u32) -> u32 {
+    return (x & z) | (y & ~z);
+}
+
+fn h_func(x: u32, y: u32, z: u32) -> u32 {
+    return x ^ y ^ z;
+}
+
+fn i_func(x: u32, y: u32, z: u32) -> u32 {
+    return y ^ (x | ~z);
+}
+
+// Process a single 512-bit (64 byte) block
+fn md5_transform(state: ptr<function, array<u32, 4>>, block_offset: u32) {
+    var m: array<u32, 16>;
+
+    // Load message block (16 words, little-endian - MD5 uses LE)
+    for (var i = 0u; i < 16u; i++) {
+        m[i] = inputs[block_offset + i];
+    }
+
+    var a = (*state)[0];
+    var b = (*state)[1];
+    var c = (*state)[2];
+    var d = (*state)[3];
+
+    // Round 1 (F function)
+    for (var i = 0u; i < 16u; i++) {
+        let f = f_func(b, c, d);
+        let g = i;
+        let temp = d;
+        d = c;
+        c = b;
+        b = b + rotl(a + f + K[i] + m[g], S[i]);
+        a = temp;
+    }
+
+    // Round 2 (G function)
+    for (var i = 16u; i < 32u; i++) {
+        let f = g_func(b, c, d);
+        let g = (5u * (i - 16u) + 1u) % 16u;
+        let temp = d;
+        d = c;
+        c = b;
+        b = b + rotl(a + f + K[i] + m[g], S[i]);
+        a = temp;
+    }
+
+    // Round 3 (H function)
+    for (var i = 32u; i < 48u; i++) {
+        let f = h_func(b, c, d);
+        let g = (3u * (i - 32u) + 5u) % 16u;
+        let temp = d;
+        d = c;
+        c = b;
+        b = b + rotl(a + f + K[i] + m[g], S[i]);
+        a = temp;
+    }
+
+    // Round 4 (I function)
+    for (var i = 48u; i < 64u; i++) {
+        let f = i_func(b, c, d);
+        let g = (7u * (i - 48u)) % 16u;
+        let temp = d;
+        d = c;
+        c = b;
+        b = b + rotl(a + f + K[i] + m[g], S[i]);
+        a = temp;
+    }
+
+    (*state)[0] += a;
+    (*state)[1] += b;
+    (*state)[2] += c;
+    (*state)[3] += d;
+}
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+
+    if idx >= params.input_count {
+        return;
+    }
+
+    // Initialize hash state
+    var state: array<u32, 4>;
+    state[0] = A0;
+    state[1] = B0;
+    state[2] = C0;
+    state[3] = D0;
+
+    // Calculate input offset (in u32s)
+    let input_offset = idx * (params.input_stride / 4u);
+
+    // Process single block (assuming pre-padded 64-byte input)
+    md5_transform(&state, input_offset);
+
+    // Write output (MD5 = 16 bytes, duplicate to 32 bytes)
+    let output_offset = idx * 8u;
+    // First 16 bytes
+    outputs[output_offset + 0u] = state[0];
+    outputs[output_offset + 1u] = state[1];
+    outputs[output_offset + 2u] = state[2];
+    outputs[output_offset + 3u] = state[3];
+    // Duplicate to fill 32 bytes
+    outputs[output_offset + 4u] = state[0];
+    outputs[output_offset + 5u] = state[1];
+    outputs[output_offset + 6u] = state[2];
+    outputs[output_offset + 7u] = state[3];
+}

--- a/src/gpu/shaders/mod.rs
+++ b/src/gpu/shaders/mod.rs
@@ -1,0 +1,10 @@
+//! WGSL shader sources.
+
+/// MT19937 Mersenne Twister shader source.
+pub const MT19937_SHADER: &str = include_str!("mt19937.wgsl");
+
+/// SHA256 hash shader source.
+pub const SHA256_SHADER: &str = include_str!("sha256.wgsl");
+
+/// MD5 hash shader source.
+pub const MD5_SHADER: &str = include_str!("md5.wgsl");

--- a/src/gpu/shaders/mt19937.wgsl
+++ b/src/gpu/shaders/mt19937.wgsl
@@ -1,0 +1,122 @@
+// MT19937 Mersenne Twister PRNG brute-force shader
+//
+// Tests seeds from a range to find one that produces a target 32-byte key.
+// Uses atomic operations for early termination when match is found.
+//
+// Optimized version:
+// - Workgroup size 256 for better GPU utilization
+// - Vec4 comparison for SIMD-style matching
+
+// MT19937 constants
+const N: u32 = 624u;
+const M: u32 = 397u;
+const MATRIX_A: u32 = 0x9908b0dfu;
+const UPPER_MASK: u32 = 0x80000000u;
+const LOWER_MASK: u32 = 0x7fffffffu;
+
+// Tempering constants
+const TEMPERING_MASK_B: u32 = 0x9d2c5680u;
+const TEMPERING_MASK_C: u32 = 0xefc60000u;
+
+// Input: range of seeds to test
+struct Params {
+    seed_start: u32,
+    seed_count: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> target_key: array<u32, 8>;
+@group(0) @binding(2) var<storage, read_write> result: atomic<u32>;
+@group(0) @binding(3) var<storage, read_write> found_flag: atomic<u32>;
+
+// MT19937 state - stored in private memory per thread
+// Note: This is large (2496 bytes) and limits occupancy
+var<private> mt: array<u32, 624>;
+var<private> mti: u32;
+
+fn mt_seed(seed: u32) {
+    mt[0] = seed;
+    for (var i = 1u; i < N; i++) {
+        mt[i] = 1812433253u * (mt[i - 1u] ^ (mt[i - 1u] >> 30u)) + i;
+    }
+    mti = N;
+}
+
+fn mt_twist() {
+    for (var i = 0u; i < N - M; i++) {
+        let y = (mt[i] & UPPER_MASK) | (mt[i + 1u] & LOWER_MASK);
+        mt[i] = mt[i + M] ^ (y >> 1u) ^ select(0u, MATRIX_A, (y & 1u) != 0u);
+    }
+    for (var i = N - M; i < N - 1u; i++) {
+        let y = (mt[i] & UPPER_MASK) | (mt[i + 1u] & LOWER_MASK);
+        mt[i] = mt[i + M - N] ^ (y >> 1u) ^ select(0u, MATRIX_A, (y & 1u) != 0u);
+    }
+    let y = (mt[N - 1u] & UPPER_MASK) | (mt[0] & LOWER_MASK);
+    mt[N - 1u] = mt[M - 1u] ^ (y >> 1u) ^ select(0u, MATRIX_A, (y & 1u) != 0u);
+    mti = 0u;
+}
+
+fn mt_next() -> u32 {
+    if mti >= N {
+        mt_twist();
+    }
+
+    var y = mt[mti];
+    mti++;
+
+    // Tempering
+    y ^= y >> 11u;
+    y ^= (y << 7u) & TEMPERING_MASK_B;
+    y ^= (y << 15u) & TEMPERING_MASK_C;
+    y ^= y >> 18u;
+
+    return y;
+}
+
+@compute @workgroup_size(128)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+
+    // Early exit if already found (check before heavy computation)
+    if atomicLoad(&found_flag) != 0u {
+        return;
+    }
+
+    // Check bounds
+    if idx >= params.seed_count {
+        return;
+    }
+
+    let seed = params.seed_start + idx;
+
+    // Initialize MT19937 with this seed
+    mt_seed(seed);
+
+    // Generate 8 u32s (32 bytes) and compare using vec4 for SIMD-style matching
+    let k0 = mt_next();
+    let k1 = mt_next();
+    let k2 = mt_next();
+    let k3 = mt_next();
+    let k4 = mt_next();
+    let k5 = mt_next();
+    let k6 = mt_next();
+    let k7 = mt_next();
+
+    // Vec4 comparison - 2 comparisons instead of 8
+    let key_lo = vec4<u32>(k0, k1, k2, k3);
+    let key_hi = vec4<u32>(k4, k5, k6, k7);
+    let target_lo = vec4<u32>(target_key[0], target_key[1], target_key[2], target_key[3]);
+    let target_hi = vec4<u32>(target_key[4], target_key[5], target_key[6], target_key[7]);
+
+    let matches = all(key_lo == target_lo) && all(key_hi == target_hi);
+
+    if matches {
+        // Try to be the first to set the result
+        let old = atomicCompareExchangeWeak(&found_flag, 0u, 1u);
+        if old.exchanged {
+            atomicStore(&result, seed);
+        }
+    }
+}

--- a/src/gpu/shaders/sha256.wgsl
+++ b/src/gpu/shaders/sha256.wgsl
@@ -1,0 +1,162 @@
+// SHA256 hash compute shader
+//
+// Computes SHA256 hashes for batches of pre-padded input blocks.
+// Each thread processes one input message.
+
+// SHA256 round constants
+const K: array<u32, 64> = array<u32, 64>(
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+    0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+    0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+    0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+    0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+    0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+    0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+    0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+    0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+    0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+    0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
+    0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+    0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
+    0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+    0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+    0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+);
+
+// Initial hash values
+const H0: u32 = 0x6a09e667u;
+const H1: u32 = 0xbb67ae85u;
+const H2: u32 = 0x3c6ef372u;
+const H3: u32 = 0xa54ff53au;
+const H4: u32 = 0x510e527fu;
+const H5: u32 = 0x9b05688cu;
+const H6: u32 = 0x1f83d9abu;
+const H7: u32 = 0x5be0cd19u;
+
+struct Params {
+    input_count: u32,
+    input_stride: u32,  // bytes per input (padded block size)
+    _pad0: u32,
+    _pad1: u32,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> inputs: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputs: array<u32>;
+
+fn rotr(x: u32, n: u32) -> u32 {
+    return (x >> n) | (x << (32u - n));
+}
+
+// Reverse byte order (for big-endian <-> little-endian conversion)
+fn reverse_bytes(x: u32) -> u32 {
+    return ((x & 0x000000ffu) << 24u) |
+           ((x & 0x0000ff00u) << 8u) |
+           ((x & 0x00ff0000u) >> 8u) |
+           ((x & 0xff000000u) >> 24u);
+}
+
+fn ch(x: u32, y: u32, z: u32) -> u32 {
+    return (x & y) ^ (~x & z);
+}
+
+fn maj(x: u32, y: u32, z: u32) -> u32 {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+fn sigma0(x: u32) -> u32 {
+    return rotr(x, 2u) ^ rotr(x, 13u) ^ rotr(x, 22u);
+}
+
+fn sigma1(x: u32) -> u32 {
+    return rotr(x, 6u) ^ rotr(x, 11u) ^ rotr(x, 25u);
+}
+
+fn gamma0(x: u32) -> u32 {
+    return rotr(x, 7u) ^ rotr(x, 18u) ^ (x >> 3u);
+}
+
+fn gamma1(x: u32) -> u32 {
+    return rotr(x, 17u) ^ rotr(x, 19u) ^ (x >> 10u);
+}
+
+// Process a single 512-bit (64 byte) block
+fn sha256_transform(state: ptr<function, array<u32, 8>>, block_offset: u32) {
+    var w: array<u32, 64>;
+
+    // Load message block and convert from little-endian (native) to big-endian (SHA256 spec)
+    for (var i = 0u; i < 16u; i++) {
+        w[i] = reverse_bytes(inputs[block_offset + i]);
+    }
+
+    // Extend to 64 words
+    for (var i = 16u; i < 64u; i++) {
+        w[i] = gamma1(w[i - 2u]) + w[i - 7u] + gamma0(w[i - 15u]) + w[i - 16u];
+    }
+
+    // Working variables
+    var a = (*state)[0];
+    var b = (*state)[1];
+    var c = (*state)[2];
+    var d = (*state)[3];
+    var e = (*state)[4];
+    var f = (*state)[5];
+    var g = (*state)[6];
+    var h = (*state)[7];
+
+    // Compression function
+    for (var i = 0u; i < 64u; i++) {
+        let t1 = h + sigma1(e) + ch(e, f, g) + K[i] + w[i];
+        let t2 = sigma0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    // Update state
+    (*state)[0] += a;
+    (*state)[1] += b;
+    (*state)[2] += c;
+    (*state)[3] += d;
+    (*state)[4] += e;
+    (*state)[5] += f;
+    (*state)[6] += g;
+    (*state)[7] += h;
+}
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let idx = global_id.x;
+
+    if idx >= params.input_count {
+        return;
+    }
+
+    // Initialize hash state
+    var state: array<u32, 8>;
+    state[0] = H0;
+    state[1] = H1;
+    state[2] = H2;
+    state[3] = H3;
+    state[4] = H4;
+    state[5] = H5;
+    state[6] = H6;
+    state[7] = H7;
+
+    // Calculate input offset (in u32s)
+    let input_offset = idx * (params.input_stride / 4u);
+
+    // Process single block (assuming pre-padded 64-byte input)
+    sha256_transform(&state, input_offset);
+
+    // Write output (8 u32s = 32 bytes), converting from big-endian to little-endian (native)
+    let output_offset = idx * 8u;
+    for (var i = 0u; i < 8u; i++) {
+        outputs[output_offset + i] = reverse_bytes(state[i]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ pub mod output;
 pub mod benchmark;
 pub mod network;
 
+#[cfg(feature = "gpu")]
+pub mod gpu;
+
 pub use transform::Key;
 
 /// Default progress bar style for CLI operations.

--- a/src/transform/double_sha256.rs
+++ b/src/transform/double_sha256.rs
@@ -14,22 +14,61 @@ impl Transform for DoubleSha256Transform {
         for input in inputs {
             // Double hash string representation
             let hash1 = Sha256::digest(input.string_val.as_bytes());
-            let hash2 = Sha256::digest(&hash1);
+            let hash2 = Sha256::digest(hash1);
             output.push((input.string_val.clone(), hash2.into()));
 
             // Double hash big-endian bytes
             if let Some(be) = input.bytes_be {
                 let h1 = Sha256::digest(be);
-                let h2 = Sha256::digest(&h1);
+                let h2 = Sha256::digest(h1);
                 output.push((input.string_val.clone(), h2.into()));
             }
 
-            // Double hash little-endian bytes
             if let Some(le) = input.bytes_le {
                 let h1 = Sha256::digest(le);
-                let h2 = Sha256::digest(&h1);
+                let h2 = Sha256::digest(h1);
                 output.push((input.string_val.clone(), h2.into()));
             }
         }
+    }
+
+    #[cfg(feature = "gpu")]
+    fn supports_gpu(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_batch_gpu(
+        &self,
+        ctx: &crate::gpu::GpuContext,
+        inputs: &[Input],
+        output: &mut Vec<(String, Key)>,
+    ) -> Result<(), crate::gpu::GpuError> {
+        use crate::gpu::{GpuHashPipeline, hash::HashAlgorithm};
+
+        let pipeline = GpuHashPipeline::new(ctx)?;
+        let result = pipeline.process_batch(HashAlgorithm::DoubleSha256, inputs)?;
+
+        for (idx, hash) in result.processed_indices.iter().zip(result.hashes.iter()) {
+            output.push((inputs[*idx].string_val.clone(), *hash));
+        }
+
+        for input in result.cpu_fallback {
+            let h1 = Sha256::digest(input.string_val.as_bytes());
+            output.push((input.string_val.clone(), Sha256::digest(h1).into()));
+        }
+
+        for input in inputs {
+            if let Some(be) = input.bytes_be {
+                let h1 = Sha256::digest(be);
+                output.push((input.string_val.clone(), Sha256::digest(h1).into()));
+            }
+            if let Some(le) = input.bytes_le {
+                let h1 = Sha256::digest(le);
+                output.push((input.string_val.clone(), Sha256::digest(h1).into()));
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/transform/md5.rs
+++ b/src/transform/md5.rs
@@ -20,4 +20,36 @@ impl Transform for Md5Transform {
             output.push((input.string_val.clone(), key));
         }
     }
+
+    #[cfg(feature = "gpu")]
+    fn supports_gpu(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_batch_gpu(
+        &self,
+        ctx: &crate::gpu::GpuContext,
+        inputs: &[Input],
+        output: &mut Vec<(String, Key)>,
+    ) -> Result<(), crate::gpu::GpuError> {
+        use crate::gpu::{GpuHashPipeline, hash::HashAlgorithm};
+
+        let pipeline = GpuHashPipeline::new(ctx)?;
+        let result = pipeline.process_batch(HashAlgorithm::Md5, inputs)?;
+
+        for (idx, hash) in result.processed_indices.iter().zip(result.hashes.iter()) {
+            output.push((inputs[*idx].string_val.clone(), *hash));
+        }
+
+        for input in result.cpu_fallback {
+            let hash = Md5::digest(input.string_val.as_bytes());
+            let mut key = [0u8; 32];
+            key[0..16].copy_from_slice(&hash);
+            key[16..32].copy_from_slice(&hash);
+            output.push((input.string_val.clone(), key));
+        }
+
+        Ok(())
+    }
 }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -38,6 +38,26 @@ pub trait Transform: Send + Sync {
 
     /// Process a batch of inputs and append results to output buffer
     fn apply_batch(&self, inputs: &[Input], output: &mut Vec<(String, Key)>);
+
+    /// Whether this transform supports GPU acceleration
+    #[cfg(feature = "gpu")]
+    fn supports_gpu(&self) -> bool {
+        false
+    }
+
+    /// Process a batch of inputs using GPU acceleration
+    ///
+    /// Default implementation falls back to CPU.
+    #[cfg(feature = "gpu")]
+    fn apply_batch_gpu(
+        &self,
+        _ctx: &crate::gpu::GpuContext,
+        inputs: &[Input],
+        output: &mut Vec<(String, Key)>,
+    ) -> Result<(), crate::gpu::GpuError> {
+        self.apply_batch(inputs, output);
+        Ok(())
+    }
 }
 
 /// Available transform types

--- a/src/transform/sha256.rs
+++ b/src/transform/sha256.rs
@@ -27,4 +27,41 @@ impl Transform for Sha256Transform {
             }
         }
     }
+
+    #[cfg(feature = "gpu")]
+    fn supports_gpu(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_batch_gpu(
+        &self,
+        ctx: &crate::gpu::GpuContext,
+        inputs: &[Input],
+        output: &mut Vec<(String, Key)>,
+    ) -> Result<(), crate::gpu::GpuError> {
+        use crate::gpu::{GpuHashPipeline, hash::HashAlgorithm};
+
+        let pipeline = GpuHashPipeline::new(ctx)?;
+        let result = pipeline.process_batch(HashAlgorithm::Sha256, inputs)?;
+
+        for (idx, hash) in result.processed_indices.iter().zip(result.hashes.iter()) {
+            output.push((inputs[*idx].string_val.clone(), *hash));
+        }
+
+        for input in result.cpu_fallback {
+            output.push((input.string_val.clone(), Sha256::digest(input.string_val.as_bytes()).into()));
+        }
+
+        for input in inputs {
+            if let Some(be) = input.bytes_be {
+                output.push((input.string_val.clone(), Sha256::digest(be).into()));
+            }
+            if let Some(le) = input.bytes_le {
+                output.push((input.string_val.clone(), Sha256::digest(le).into()));
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Adds GPU acceleration using wgpu to massively speed up hash computations and MT19937 brute-force operations. This enables practical use of vuke against large-scale analysis tasks that were previously CPU-bound.

Closes #9

## Changes

- **New `src/gpu/` module** with wgpu backend (Vulkan/Metal/DX12 support)
- **WGSL shaders** for SHA256, double-SHA256, MD5, and MT19937
- **GPU-accelerated transforms** (`--transform sha256/double_sha256/md5` with `--gpu`)
- **GPU-accelerated milksad analyzer** for fast 2^32 seed brute-force
- **Optional feature flag** (`--features gpu`) - no runtime dependency without it
- **Automatic CPU fallback** when GPU is unavailable

## Testing

- `cargo test --features gpu` - 155 tests pass
- Manual test with AMD Radeon RX 6800S (Vulkan): GPU correctly detected and used
- Verified CPU fallback works when GPU feature disabled

---
Co-Authored-By: Aei <aei@oad.earth>