### PR TITLE
feat(storage): add Hive-style partitioning

### DIFF
--- a/src/storage/AGENTS.md
+++ b/src/storage/AGENTS.md
@@ -67,7 +67,7 @@ pub trait StorageBackend: Send + Sync {
 ## PARQUET BACKEND
 
 ```rust
-ParquetBackend::new("results/")
+ParquetBackend::new("results/", "milksad")
     .with_compression(Compression::ZSTD(Default::default()))
     .with_chunk_records(1_000_000)
     .with_chunk_bytes(100 * 1024 * 1024)
@@ -80,14 +80,18 @@ ParquetBackend::new("results/")
 | `without_chunking()` | - | Disable auto-rotation |
 | `with_compression(c)` | ZSTD | Set compression algorithm |
 
-Chunk naming: `{YYYY-MM-DD}_chunk_{NNNN}.parquet`
+Hive-style partitioning: `transform={name}/date={YYYY-MM-DD}/chunk_{NNNN}.parquet`
 
 Output structure:
 ```
 results/
-  2025-01-15_chunk_0001.parquet
-  2025-01-15_chunk_0002.parquet
-  ...
+  transform=milksad/
+    date=2025-01-15/
+      chunk_0001.parquet
+      chunk_0002.parquet
+  transform=sha256/
+    date=2025-01-15/
+      chunk_0001.parquet
 ```
 
 ## RECORD TYPES
@@ -118,7 +122,7 @@ results/
 - #34 - Arrow schema for results (done)
 - #35 - ParquetBackend implementation (done)
 - #36 - Automatic chunk rotation (done)
-- #37 - Basic partitioning (transform/date)
+- #37 - Basic partitioning (transform/date) (done)
 - #38 - CLI `--storage` flag integration
 
 ## DEPENDENCIES


### PR DESCRIPTION
## Summary

Implements Hive-style partitioning for efficient data organization and query pruning.

Closes #37

## Changes

- Add required `transform` parameter to `ParquetBackend::new()`
- Generate Hive-style partition paths: `transform=X/date=Y/chunk_NNNN.parquet`
- Update `ensure_writer()` to create nested partition directories on-demand
- Add integration test verifying partition structure

## Output Structure

```
results/
  transform=milksad/
    date=2025-12-31/
      chunk_0001.parquet
  transform=sha256/
    date=2025-12-31/
      chunk_0001.parquet
```

## Testing

- All 243 storage tests pass
- New test: `creates_hive_partitioned_structure`

---
Co-Authored-By: Aei <aei@oad.earth>