### PR TITLE
feat(storage): add CLI --storage flag

### DIFF
--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -84,13 +84,24 @@ impl Output for ConsoleOutput {
         Ok(())
     }
 
-    fn hit(&self, source: &str, transform: &str, derived: &DerivedKey, match_info: &MatchInfo) -> Result<()> {
+    fn hit(
+        &self,
+        source: &str,
+        transform: &str,
+        derived: &DerivedKey,
+        match_info: &MatchInfo,
+    ) -> Result<()> {
         let mut w = self.writer.lock().unwrap();
 
         writeln!(w, "\n========== HIT ==========")?;
         writeln!(w, "Source: {}", source)?;
         writeln!(w, "Transform: {}", transform)?;
-        writeln!(w, "Matched: {} ({})", match_info.address, match_info.address_type.as_str())?;
+        writeln!(
+            w,
+            "Matched: {} ({})",
+            match_info.address,
+            match_info.address_type.as_str()
+        )?;
         writeln!(w, "---")?;
         writeln!(w, "Private Key: {}", derived.private_key_hex)?;
         writeln!(w, "WIF (compressed): {}", derived.wif_compressed)?;
@@ -118,6 +129,11 @@ mod tests {
 
     fn make_test_key() -> DerivedKey {
         DerivedKey {
+            raw: [
+                0xab, 0xc1, 0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+            ],
             private_key_hex: "abc123".to_string(),
             private_key_decimal: "123".to_string(),
             private_key_binary: "101".to_string(),
@@ -139,7 +155,9 @@ mod tests {
         let temp = NamedTempFile::new().unwrap();
         let output = ConsoleOutput::to_file(temp.path()).unwrap();
 
-        output.key("test_source", "sha256", &make_test_key()).unwrap();
+        output
+            .key("test_source", "sha256", &make_test_key())
+            .unwrap();
         output.flush().unwrap();
 
         let content = std::fs::read_to_string(temp.path()).unwrap();
@@ -151,7 +169,9 @@ mod tests {
         let temp = NamedTempFile::new().unwrap();
         let output = ConsoleOutput::to_file_verbose(temp.path()).unwrap();
 
-        output.key("test_source", "sha256", &make_test_key()).unwrap();
+        output
+            .key("test_source", "sha256", &make_test_key())
+            .unwrap();
         output.flush().unwrap();
 
         let content = std::fs::read_to_string(temp.path()).unwrap();

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,12 +1,18 @@
 //! Output handlers for generated keys.
 
 mod console;
+mod multi;
+#[cfg(feature = "storage")]
+mod storage;
 
 pub use console::ConsoleOutput;
+pub use multi::MultiOutput;
+#[cfg(feature = "storage")]
+pub use storage::{StorageOutput, StorageSummary};
 
-use anyhow::Result;
 use crate::derive::DerivedKey;
 use crate::matcher::MatchInfo;
+use anyhow::Result;
 
 /// Output trait for handling generated keys.
 pub trait Output: Send + Sync {
@@ -14,7 +20,13 @@ pub trait Output: Send + Sync {
     fn key(&self, source: &str, transform: &str, derived: &DerivedKey) -> Result<()>;
 
     /// Output a match hit (matcher found target).
-    fn hit(&self, source: &str, transform: &str, derived: &DerivedKey, match_info: &MatchInfo) -> Result<()>;
+    fn hit(
+        &self,
+        source: &str,
+        transform: &str,
+        derived: &DerivedKey,
+        match_info: &MatchInfo,
+    ) -> Result<()>;
 
     /// Flush any buffered output.
     fn flush(&self) -> Result<()>;

--- a/src/output/multi.rs
+++ b/src/output/multi.rs
@@ -1,0 +1,152 @@
+use anyhow::Result;
+
+use super::Output;
+use crate::derive::DerivedKey;
+use crate::matcher::MatchInfo;
+
+pub struct MultiOutput {
+    outputs: Vec<Box<dyn Output>>,
+}
+
+impl MultiOutput {
+    pub fn new(outputs: Vec<Box<dyn Output>>) -> Self {
+        Self { outputs }
+    }
+}
+
+impl Output for MultiOutput {
+    fn key(&self, source: &str, transform: &str, derived: &DerivedKey) -> Result<()> {
+        for output in &self.outputs {
+            output.key(source, transform, derived)?;
+        }
+        Ok(())
+    }
+
+    fn hit(
+        &self,
+        source: &str,
+        transform: &str,
+        derived: &DerivedKey,
+        match_info: &MatchInfo,
+    ) -> Result<()> {
+        for output in &self.outputs {
+            output.hit(source, transform, derived, match_info)?;
+        }
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<()> {
+        for output in &self.outputs {
+            output.flush()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    struct CountingOutput {
+        key_count: Arc<AtomicU64>,
+        hit_count: Arc<AtomicU64>,
+    }
+
+    impl Output for CountingOutput {
+        fn key(&self, _source: &str, _transform: &str, _derived: &DerivedKey) -> Result<()> {
+            self.key_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn hit(
+            &self,
+            _source: &str,
+            _transform: &str,
+            _derived: &DerivedKey,
+            _match_info: &MatchInfo,
+        ) -> Result<()> {
+            self.hit_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_test_derived() -> DerivedKey {
+        DerivedKey {
+            raw: [1u8; 32],
+            private_key_hex: "01".repeat(32),
+            private_key_decimal: "1".to_string(),
+            private_key_binary: "0".repeat(256),
+            bit_length: 1,
+            hamming_weight: 1,
+            leading_zeros: 62,
+            pubkey_compressed: "02abc".to_string(),
+            pubkey_uncompressed: "04abc".to_string(),
+            wif_compressed: "L1".to_string(),
+            wif_uncompressed: "5J".to_string(),
+            p2pkh_compressed: "1ABC".to_string(),
+            p2pkh_uncompressed: "1DEF".to_string(),
+            p2wpkh: "bc1q".to_string(),
+        }
+    }
+
+    #[test]
+    fn calls_all_outputs_on_key() {
+        let count1 = Arc::new(AtomicU64::new(0));
+        let count2 = Arc::new(AtomicU64::new(0));
+
+        let out1 = CountingOutput {
+            key_count: Arc::clone(&count1),
+            hit_count: Arc::new(AtomicU64::new(0)),
+        };
+        let out2 = CountingOutput {
+            key_count: Arc::clone(&count2),
+            hit_count: Arc::new(AtomicU64::new(0)),
+        };
+
+        let multi = MultiOutput::new(vec![Box::new(out1), Box::new(out2)]);
+        multi.key("src", "sha256", &make_test_derived()).unwrap();
+
+        assert_eq!(count1.load(Ordering::Relaxed), 1);
+        assert_eq!(count2.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn calls_all_outputs_on_hit() {
+        let count1 = Arc::new(AtomicU64::new(0));
+        let count2 = Arc::new(AtomicU64::new(0));
+
+        let out1 = CountingOutput {
+            key_count: Arc::new(AtomicU64::new(0)),
+            hit_count: Arc::clone(&count1),
+        };
+        let out2 = CountingOutput {
+            key_count: Arc::new(AtomicU64::new(0)),
+            hit_count: Arc::clone(&count2),
+        };
+
+        let multi = MultiOutput::new(vec![Box::new(out1), Box::new(out2)]);
+        let match_info = MatchInfo {
+            address: "1ABC".to_string(),
+            address_type: crate::matcher::AddressType::P2pkhCompressed,
+        };
+        multi
+            .hit("src", "sha256", &make_test_derived(), &match_info)
+            .unwrap();
+
+        assert_eq!(count1.load(Ordering::Relaxed), 1);
+        assert_eq!(count2.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn empty_multi_output() {
+        let multi = MultiOutput::new(vec![]);
+        multi.key("src", "sha256", &make_test_derived()).unwrap();
+        multi.flush().unwrap();
+    }
+}

--- a/src/output/storage.rs
+++ b/src/output/storage.rs
@@ -1,0 +1,384 @@
+//! Parquet storage output handler.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use chrono::Utc;
+
+use super::Output;
+use crate::derive::DerivedKey;
+use crate::matcher::MatchInfo;
+use crate::storage::{
+    AddressRecord, ExportFormatRecord, ParquetBackend, PrivateKeyRecord, PublicKeyRecord,
+    ResultRecord, StorageBackend,
+};
+
+struct StorageInner {
+    backend: Mutex<Option<ParquetBackend>>,
+    records_written: AtomicU64,
+    chain: String,
+    base_dir: PathBuf,
+    transform: String,
+    chunk_records: u64,
+    chunk_bytes: u64,
+}
+
+#[derive(Clone)]
+pub struct StorageOutput {
+    inner: Arc<StorageInner>,
+}
+
+pub struct StorageSummary {
+    pub paths: Vec<PathBuf>,
+    pub records_written: u64,
+}
+
+impl StorageOutput {
+    pub fn new(base_dir: impl AsRef<Path>, transform: &str) -> Result<Self> {
+        let base_dir = base_dir.as_ref().to_path_buf();
+        let backend = ParquetBackend::new(&base_dir, transform);
+        Ok(Self {
+            inner: Arc::new(StorageInner {
+                backend: Mutex::new(Some(backend)),
+                records_written: AtomicU64::new(0),
+                chain: "bitcoin".to_string(),
+                base_dir,
+                transform: transform.to_string(),
+                chunk_records: 1_000_000,
+                chunk_bytes: 100 * 1024 * 1024,
+            }),
+        })
+    }
+
+    pub fn with_chunk_records(self, max_records: u64) -> Self {
+        Self {
+            inner: Arc::new(StorageInner {
+                backend: Mutex::new(Some(
+                    ParquetBackend::new(&self.inner.base_dir, &self.inner.transform)
+                        .with_chunk_records(max_records)
+                        .with_chunk_bytes(self.inner.chunk_bytes),
+                )),
+                records_written: AtomicU64::new(0),
+                chain: self.inner.chain.clone(),
+                base_dir: self.inner.base_dir.clone(),
+                transform: self.inner.transform.clone(),
+                chunk_records: max_records,
+                chunk_bytes: self.inner.chunk_bytes,
+            }),
+        }
+    }
+
+    pub fn with_chunk_bytes(self, max_bytes: u64) -> Self {
+        Self {
+            inner: Arc::new(StorageInner {
+                backend: Mutex::new(Some(
+                    ParquetBackend::new(&self.inner.base_dir, &self.inner.transform)
+                        .with_chunk_records(self.inner.chunk_records)
+                        .with_chunk_bytes(max_bytes),
+                )),
+                records_written: AtomicU64::new(0),
+                chain: self.inner.chain.clone(),
+                base_dir: self.inner.base_dir.clone(),
+                transform: self.inner.transform.clone(),
+                chunk_records: self.inner.chunk_records,
+                chunk_bytes: max_bytes,
+            }),
+        }
+    }
+
+    pub fn with_chain(self, chain: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(StorageInner {
+                backend: Mutex::new(Some(
+                    ParquetBackend::new(&self.inner.base_dir, &self.inner.transform)
+                        .with_chunk_records(self.inner.chunk_records)
+                        .with_chunk_bytes(self.inner.chunk_bytes),
+                )),
+                records_written: AtomicU64::new(0),
+                chain: chain.into(),
+                base_dir: self.inner.base_dir.clone(),
+                transform: self.inner.transform.clone(),
+                chunk_records: self.inner.chunk_records,
+                chunk_bytes: self.inner.chunk_bytes,
+            }),
+        }
+    }
+
+    pub fn records_written(&self) -> u64 {
+        self.inner.records_written.load(Ordering::Relaxed)
+    }
+
+    pub fn finish(self) -> Result<StorageSummary> {
+        let mut guard = self.inner.backend.lock().unwrap();
+        let paths = if let Some(mut backend) = guard.take() {
+            backend.flush().map_err(|e| anyhow::anyhow!("{}", e))?
+        } else {
+            Vec::new()
+        };
+        Ok(StorageSummary {
+            paths,
+            records_written: self.inner.records_written.load(Ordering::Relaxed),
+        })
+    }
+
+    fn write_record(
+        &self,
+        source: &str,
+        transform: &str,
+        derived: &DerivedKey,
+        matched_target: Option<&str>,
+    ) -> Result<()> {
+        let public_keys = [
+            PublicKeyRecord {
+                format: "compressed",
+                value: &derived.pubkey_compressed,
+            },
+            PublicKeyRecord {
+                format: "uncompressed",
+                value: &derived.pubkey_uncompressed,
+            },
+        ];
+
+        let addresses = [
+            AddressRecord {
+                address_type: "p2pkh_compressed",
+                address: &derived.p2pkh_compressed,
+            },
+            AddressRecord {
+                address_type: "p2pkh_uncompressed",
+                address: &derived.p2pkh_uncompressed,
+            },
+            AddressRecord {
+                address_type: "p2wpkh",
+                address: &derived.p2wpkh,
+            },
+        ];
+
+        let export_formats = [
+            ExportFormatRecord {
+                format: "wif_compressed",
+                value: &derived.wif_compressed,
+            },
+            ExportFormatRecord {
+                format: "wif_uncompressed",
+                value: &derived.wif_uncompressed,
+            },
+        ];
+
+        let private_key = PrivateKeyRecord {
+            raw: &derived.raw,
+            hex: &derived.private_key_hex,
+            decimal: &derived.private_key_decimal,
+            binary: &derived.private_key_binary,
+            bit_length: derived.bit_length,
+            hamming_weight: derived.hamming_weight,
+            leading_zeros: derived.leading_zeros,
+        };
+
+        let record = ResultRecord {
+            source,
+            transform,
+            chain: &self.inner.chain,
+            timestamp: Utc::now(),
+            private_key,
+            public_keys: &public_keys,
+            addresses: &addresses,
+            export_formats: &export_formats,
+            matched_target,
+        };
+
+        let mut guard = self.inner.backend.lock().unwrap();
+        if let Some(ref mut backend) = *guard {
+            backend
+                .write_batch(&[record])
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+        }
+
+        self.inner.records_written.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl Output for StorageOutput {
+    fn key(&self, source: &str, transform: &str, derived: &DerivedKey) -> Result<()> {
+        self.write_record(source, transform, derived, None)
+    }
+
+    fn hit(
+        &self,
+        source: &str,
+        transform: &str,
+        derived: &DerivedKey,
+        match_info: &MatchInfo,
+    ) -> Result<()> {
+        self.write_record(source, transform, derived, Some(&match_info.address))
+    }
+
+    fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_test_derived() -> DerivedKey {
+        DerivedKey {
+            raw: [1u8; 32],
+            private_key_hex: "0101010101010101010101010101010101010101010101010101010101010101"
+                .to_string(),
+            private_key_decimal: "123456789".to_string(),
+            private_key_binary: "0".repeat(256),
+            bit_length: 249,
+            hamming_weight: 32,
+            leading_zeros: 0,
+            pubkey_compressed: "02abc123".to_string(),
+            pubkey_uncompressed: "04abc123def456".to_string(),
+            wif_compressed: "L1234567890".to_string(),
+            wif_uncompressed: "5J1234567890".to_string(),
+            p2pkh_compressed: "1ABC123".to_string(),
+            p2pkh_uncompressed: "1DEF456".to_string(),
+            p2wpkh: "bc1qtest".to_string(),
+        }
+    }
+
+    #[test]
+    fn write_single_key() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "sha256").unwrap();
+
+        output
+            .key("test_source", "sha256", &make_test_derived())
+            .unwrap();
+
+        let summary = output.finish().unwrap();
+        assert_eq!(summary.records_written, 1);
+        assert_eq!(summary.paths.len(), 1);
+        assert!(summary.paths[0].exists());
+    }
+
+    #[test]
+    fn write_multiple_keys() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "milksad").unwrap();
+        let derived = make_test_derived();
+
+        for i in 0..10 {
+            let source = format!("source_{}", i);
+            output.key(&source, "milksad", &derived).unwrap();
+        }
+
+        let summary = output.finish().unwrap();
+        assert_eq!(summary.records_written, 10);
+    }
+
+    #[test]
+    fn write_hit_with_matched_target() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "sha256").unwrap();
+        let derived = make_test_derived();
+
+        let match_info = MatchInfo {
+            address: "1ABC123".to_string(),
+            address_type: crate::matcher::AddressType::P2pkhCompressed,
+        };
+
+        output
+            .hit("test_source", "sha256", &derived, &match_info)
+            .unwrap();
+
+        let summary = output.finish().unwrap();
+        assert_eq!(summary.records_written, 1);
+
+        let file = fs::File::open(&summary.paths[0]).unwrap();
+        let reader = ParquetRecordBatchReader::try_new(file, 1024).unwrap();
+        let batches: Vec<_> = reader.map(|r| r.unwrap()).collect();
+
+        assert_eq!(batches[0].num_rows(), 1);
+        let matched_col = batches[0]
+            .column(4)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(matched_col.value(0), "1ABC123");
+    }
+
+    #[test]
+    fn chunk_rotation() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "sha256")
+            .unwrap()
+            .with_chunk_records(3);
+        let derived = make_test_derived();
+
+        for i in 0..10 {
+            let source = format!("source_{}", i);
+            output.key(&source, "sha256", &derived).unwrap();
+        }
+
+        let summary = output.finish().unwrap();
+        assert_eq!(summary.records_written, 10);
+        assert!(summary.paths.len() >= 3);
+    }
+
+    #[test]
+    fn records_written_counter() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "sha256").unwrap();
+        let derived = make_test_derived();
+
+        assert_eq!(output.records_written(), 0);
+
+        output.key("source1", "sha256", &derived).unwrap();
+        assert_eq!(output.records_written(), 1);
+
+        output.key("source2", "sha256", &derived).unwrap();
+        assert_eq!(output.records_written(), 2);
+    }
+
+    #[test]
+    fn custom_chain() {
+        let dir = tempdir().unwrap();
+        let output = StorageOutput::new(dir.path(), "sha256")
+            .unwrap()
+            .with_chain("testnet");
+        let derived = make_test_derived();
+
+        output.key("test", "sha256", &derived).unwrap();
+        let summary = output.finish().unwrap();
+
+        let file = fs::File::open(&summary.paths[0]).unwrap();
+        let reader = ParquetRecordBatchReader::try_new(file, 1024).unwrap();
+        let batches: Vec<_> = reader.map(|r| r.unwrap()).collect();
+
+        let chain_col = batches[0]
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(chain_col.value(0), "testnet");
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let dir = tempdir().unwrap();
+        let output1 = StorageOutput::new(dir.path(), "sha256").unwrap();
+        let output2 = output1.clone();
+        let derived = make_test_derived();
+
+        output1.key("source1", "sha256", &derived).unwrap();
+        output2.key("source2", "sha256", &derived).unwrap();
+
+        assert_eq!(output1.records_written(), 2);
+        assert_eq!(output2.records_written(), 2);
+
+        let summary = output1.finish().unwrap();
+        assert_eq!(summary.records_written, 2);
+    }
+}


### PR DESCRIPTION
## Summary

Complete Phase 1 Storage MVP by adding `--storage <path>` CLI flag to persist generated keys to Parquet files. This enables TB-scale analysis workflows by writing all keys (not just hits) to storage with Hive-style partitioning.

Closes #38

## Changes

- Add `--storage`, `--chunk-records`, `--chunk-bytes` CLI flags to `generate` and `scan` commands
- Implement `StorageOutput` with `Arc<Inner>` for shared state across clones
- Add `MultiOutput` to fan out writes to both console and storage simultaneously
- Add `raw: [u8; 32]` field to `DerivedKey` for `ResultRecord` compatibility
- Print storage summary after completion (file paths, sizes)
- Graceful error when `--storage` used without `storage` feature

## Testing

- All 253 tests pass (`cargo test --features storage`)
- Manual CLI test verified Parquet output with Hive partitioning:
  ```
  vuke generate --storage=/tmp/test --transform=sha256 range --start=1 --end=50
  # Output: Storage: 1 files written (73.2 KB total)
  # Creates: /tmp/test/transform=sha256/date=2025-12-31/chunk_0001.parquet
  ```

---
Co-Authored-By: Aei <aei@oad.earth>