### PR TITLE
refactor(cli): extract shared args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ struct StorageArgs {
     #[arg(long, value_enum, default_value = "zstd")]
     compression: CompressionAlgorithm,
 
-    /// Zstd compression level (1-22, higher = slower but smaller)
+    /// Compression level (Zstd: 1-22, Gzip: 1-9; invalid levels use algorithm default)
     #[arg(long, default_value = "3", value_parser = clap::value_parser!(i32).range(1..=22))]
     compression_level: i32,
 


### PR DESCRIPTION
## Summary

Deduplicate CLI arg definitions and storage pipeline code shared between Generate and Scan commands.

Closes #59

## Changes

- Extract `StorageArgs` (13 fields) and `BitimageArgs` (4 fields) as `#[derive(clap::Args)]` structs with `#[command(flatten)]`
- Reduce `run_generate` / `run_scan` signatures from 17 parameters to 5
- Consolidate duplicated storage setup into shared helpers: `create_storage_output`, `build_output`, `finalize_storage`, `suppress_unused_storage`
- 1609 → 1409 lines (−12%)

## Testing

- `cargo check` clean across all feature combinations (default, `storage`, `storage-cloud`, `storage-iceberg`)
- `cargo test` — 225 passed, 0 failed
- LSP diagnostics clean
- No behavioral changes — pure structural refactor

---
Co-Authored-By: Aei <256851514+aeitwoen@users.noreply.github.com>