### PR TITLE
fix(output): escape compact CSV fields in compact console output

### DIFF
--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -214,14 +214,14 @@ mod tests {
     fn test_to_file_writes_compact_format_with_newlines_in_source() {
         let temp = NamedTempFile::new().unwrap();
         let output = ConsoleOutput::to_file(temp.path()).unwrap();
+        let source = "line1\nline2";
 
-        output
-            .key("line1\nline2", "sha256", &make_test_key())
-            .unwrap();
+        output.key(source, "sha256", &make_test_key()).unwrap();
         output.flush().unwrap();
 
         let content = std::fs::read_to_string(temp.path()).unwrap();
-        assert!(content.contains("\"line1\nline2\",sha256,abc123,1Address"));
+        let expected_row = format_compact_csv_row(source, "sha256", "abc123", "1Address");
+        assert_eq!(content, format!("{}\n", expected_row));
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,7 +19,15 @@ use crate::matcher::MatchInfo;
 use anyhow::Result;
 
 pub(crate) fn escape_csv_field(field: &str) -> String {
-    if field.contains(',') || field.contains('"') || field.contains('\n') || field.contains('\r') {
+    let has_boundary_whitespace = field.chars().next().is_some_and(char::is_whitespace)
+        || field.chars().last().is_some_and(char::is_whitespace);
+
+    if has_boundary_whitespace
+        || field.contains(',')
+        || field.contains('"')
+        || field.contains('\n')
+        || field.contains('\r')
+    {
         format!("\"{}\"", field.replace('"', "\"\""))
     } else {
         field.to_string()

--- a/src/output/query_format.rs
+++ b/src/output/query_format.rs
@@ -375,6 +375,22 @@ mod tests {
     }
 
     #[test]
+    fn escape_csv_field_with_boundary_whitespace() {
+        assert_eq!(escape_csv_field(" leading"), "\" leading\"");
+        assert_eq!(escape_csv_field("trailing "), "\"trailing \"");
+        assert_eq!(escape_csv_field("\ttab"), "\"\ttab\"");
+        assert_eq!(escape_csv_field("tab\t"), "\"tab\t\"");
+        assert_eq!(
+            escape_csv_field("\u{00A0}nbsp-leading"),
+            "\"\u{00A0}nbsp-leading\""
+        );
+        assert_eq!(
+            escape_csv_field("nbsp-trailing\u{00A0}"),
+            "\"nbsp-trailing\u{00A0}\""
+        );
+    }
+
+    #[test]
     fn format_value_json_types() {
         assert_eq!(format_value_json(&Value::Null), "null");
         assert_eq!(format_value_json(&Value::Int64(42)), "42");


### PR DESCRIPTION
Closes #70.

I tripped over this while checking compact output for passphrases that include punctuation. A comma in `source` shifted columns, so downstream parsing got misaligned.

This change makes compact output serialize each field with RFC 4180-style escaping instead of raw string interpolation. It also moves CSV field escaping into a shared helper so query CSV and compact console output use the same rules.

What changed:
- compact output now writes a properly escaped CSV row in `ConsoleOutput::key`
- extracted `escape_csv_field` to `src/output/mod.rs` and reused it from `query_format.rs`
- added compact output tests for commas, quotes, and newlines in `source`

Validation run:
- `cargo test --lib output::console`
- `cargo test --features storage-query output::query_format`
- `cargo build`
- `cubic review -p \"Focus on real bugs, security issues, logic errors, type safety problems, and missed edge cases. Skip cosmetic nits and formatting that linters handle. Be direct and specific: what is wrong, where, and why it matters. No filler, no praise, no generic advice.\"`
- `coderabbit review --plain --type uncommitted`

Note: full `cargo test` currently has one pre-existing unrelated failure in `analyze::lcg::tests::test_masked_analysis`.