### PR TITLE
fix(network): reject invalid network names instead of silent default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,7 @@ fn main() -> Result<()> {
             storage_args,
             bitimage_args,
         } => {
-            let network = parse_network(&network);
+            let network = parse_network(&network)?;
             let transform = apply_bitimage_config(transform, &bitimage_args);
             run_generate(source, transform, network, output, verbose, &storage_args)
         }
@@ -409,7 +409,7 @@ fn main() -> Result<()> {
             storage_args,
             bitimage_args,
         } => {
-            let network = parse_network(&network);
+            let network = parse_network(&network)?;
             let transform = apply_bitimage_config(transform, &bitimage_args);
             run_scan(source, transform, network, targets, output, &storage_args)
         }
@@ -735,7 +735,7 @@ fn run_scan(
 fn run_single(passphrase: &str, transform_type: TransformType, network: &str) -> Result<()> {
     use vuke::transform::Input;
 
-    let net = parse_network(network);
+    let net = parse_network(network)?;
     let deriver = KeyDeriver::with_network(net);
     let transform = transform_type.create();
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,18 +1,22 @@
 //! Bitcoin network configuration.
 
+use anyhow::{bail, Result};
 use bitcoin::Network;
 
 /// Parse network string to Network enum.
-pub fn parse_network(network: &str) -> Network {
+///
+/// Returns an error for unrecognized network names instead of silently
+/// defaulting to mainnet.
+pub fn parse_network(network: &str) -> Result<Network> {
     match network.to_lowercase().as_str() {
-        "bitcoin" | "mainnet" | "main" => Network::Bitcoin,
-        "testnet" | "test" => Network::Testnet,
-        "signet" => Network::Signet,
-        "regtest" | "reg" => Network::Regtest,
-        _ => {
-            eprintln!("Unknown network: {}. Defaulting to Bitcoin.", network);
-            Network::Bitcoin
-        }
+        "bitcoin" | "mainnet" | "main" => Ok(Network::Bitcoin),
+        "testnet" | "test" => Ok(Network::Testnet),
+        "signet" => Ok(Network::Signet),
+        "regtest" | "reg" => Ok(Network::Regtest),
+        _ => bail!(
+            "unknown network '{}'. Valid options: bitcoin, testnet, signet, regtest",
+            network
+        ),
     }
 }
 
@@ -21,13 +25,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_network() {
-        assert_eq!(parse_network("bitcoin"), Network::Bitcoin);
-        assert_eq!(parse_network("mainnet"), Network::Bitcoin);
-        assert_eq!(parse_network("BITCOIN"), Network::Bitcoin);
-        assert_eq!(parse_network("testnet"), Network::Testnet);
-        assert_eq!(parse_network("signet"), Network::Signet);
-        assert_eq!(parse_network("regtest"), Network::Regtest);
-        assert_eq!(parse_network("unknown"), Network::Bitcoin); // default
+    fn test_parse_known_networks() {
+        assert_eq!(parse_network("bitcoin").unwrap(), Network::Bitcoin);
+        assert_eq!(parse_network("mainnet").unwrap(), Network::Bitcoin);
+        assert_eq!(parse_network("BITCOIN").unwrap(), Network::Bitcoin);
+        assert_eq!(parse_network("testnet").unwrap(), Network::Testnet);
+        assert_eq!(parse_network("signet").unwrap(), Network::Signet);
+        assert_eq!(parse_network("regtest").unwrap(), Network::Regtest);
+    }
+
+    #[test]
+    fn test_parse_unknown_network_returns_error() {
+        let result = parse_network("unknown");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("unknown network"));
+        assert!(msg.contains("Valid options"));
     }
 }


### PR DESCRIPTION
`parse_network` returned `Network::Bitcoin` for any unrecognized string, with only an `eprintln` warning. For a tool that operates on private keys, silently picking the wrong network is a real problem - you'd generate addresses for the wrong chain and never know unless you caught the stderr line.

Now returns `Result<Network>` and surfaces a clear error with the valid options. All three call sites in `main.rs` already propagate `Result`, so the `?` fits naturally.

Closes #69