### PR TITLE
fix(source): stream wordlist file instead of loading into memory

### DIFF
--- a/src/source/wordlist.rs
+++ b/src/source/wordlist.rs
@@ -67,12 +67,14 @@ impl Source for WordlistSource {
                 Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
                     // read_line() already consumed the bytes, sync position from reader
                     bytes_consumed = reader.stream_position().unwrap_or(bytes_consumed);
+                    pb.set_position(bytes_consumed);
                     continue;
                 }
                 Err(e) => return Err(e.into()),
             };
 
             bytes_consumed += bytes_read;
+            pb.set_position(bytes_consumed);
 
             let trimmed = line_buf.trim().to_string();
             if trimmed.is_empty() {
@@ -86,7 +88,6 @@ impl Source for WordlistSource {
                 process_chunk(
                     &chunk, transforms, deriver, matcher, output, &stats, &matches,
                 );
-                pb.set_position(bytes_consumed);
                 chunk.clear();
             }
         }
@@ -95,7 +96,6 @@ impl Source for WordlistSource {
             process_chunk(
                 &chunk, transforms, deriver, matcher, output, &stats, &matches,
             );
-            pb.set_position(bytes_consumed);
         }
 
         pb.finish_and_clear();


### PR DESCRIPTION
WordlistSource read the entire file into `Vec<String>` before processing anything. A 2GB wordlist means 2GB+ of resident memory just for the input buffer, before any key derivation starts.

Switched to streaming with `read_line()` in chunks of 10k lines. Each chunk gets processed through Rayon `par_chunks(1000)` the same way as before, then dropped before the next chunk loads. Memory usage is now bounded by chunk size, not file size.

Progress bar tracks bytes read from the file (via `read_line()` return value) instead of line count, so it works without knowing total lines upfront and handles CRLF correctly.

Closes #71