### PR TITLE
fix(cli): show P2TR address in single subcommand output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -767,6 +767,7 @@ fn run_single(passphrase: &str, transform_type: TransformType, network: &str) ->
         println!("P2PKH (compressed):   {}", derived.p2pkh_compressed);
         println!("P2PKH (uncompressed): {}", derived.p2pkh_uncompressed);
         println!("P2WPKH:               {}", derived.p2wpkh);
+        println!("P2TR:                 {}", derived.p2tr);
     }
 
     Ok(())


### PR DESCRIPTION
P2TR support landed in #79 but the `single` subcommand still only prints P2PKH compressed, P2PKH uncompressed, and P2WPKH. Taproot address was missing from the output.