### PR TITLE
fix(provider): add P2TR address matching to key verification

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -439,6 +439,8 @@ fn verify_key_boha(key: &[u8; 32], query: &str) -> Result<VerifyReport> {
             Some("p2pkh_uncompressed")
         } else if derived.p2wpkh == addr {
             Some("p2wpkh")
+        } else if derived.p2tr == addr {
+            Some("p2tr")
         } else {
             None
         };


### PR DESCRIPTION
The \`verify_key_boha\` function checks P2PKH compressed, P2PKH uncompressed, and P2WPKH addresses against puzzle targets, but skips P2TR. If a puzzle uses a Taproot address, \`vuke analyze --verify\` won't match it even with the correct key.