### PR TITLE
fix(benchmark): use transform name instead of Debug format in JSON output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,15 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,78 +1071,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "codspeed"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b847e05a34be5c38f3f2a5052178a3bd32e6b5702f3ea775efde95c483a539"
-dependencies = [
- "anyhow",
- "cc",
- "colored",
- "getrandom 0.2.16",
- "glob",
- "libc",
- "nix",
- "serde",
- "serde_json",
- "statrs",
-]
-
-[[package]]
-name = "codspeed-criterion-compat"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a0e2a53beb18dec493ec133f226e0d35e8bb2fdc638ccf7351696eabee416c"
-dependencies = [
- "clap",
- "codspeed",
- "codspeed-criterion-compat-walltime",
- "colored",
- "regex",
-]
-
-[[package]]
-name = "codspeed-criterion-compat-walltime"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f652d6e6d40bba0f5c244744db94d92a26b7f083df18692df88fb0772f1c793"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "codspeed",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "comfy-table"
@@ -1276,6 +1199,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
@@ -1912,12 +1861,6 @@ dependencies = [
  "log",
  "xml-rs",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -2928,18 +2871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -4372,16 +4303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "statrs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
-dependencies = [
- "approx",
- "num-traits",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,8 +5038,8 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
- "codspeed-criterion-compat",
  "comfy-table",
+ "criterion",
  "duckdb",
  "futures",
  "hex",
@@ -5134,6 +5055,7 @@ dependencies = [
  "rand_mt",
  "rayon",
  "secp256k1",
+ "serde_json",
  "sha2",
  "tempfile",
  "testcontainers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde_json = "1.0"
 
 # Crypto
 sha2 = "0.10"

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -54,8 +54,8 @@ pub fn run_benchmark(transform_type: TransformType, json: bool) -> Result<()> {
 
     if json {
         println!(
-            "{{ \"name\": \"{:?}\", \"ops_per_sec\": {}, \"total_ops\": {}, \"duration_secs\": {} }}",
-            transform_type, speed as u64, count, duration
+            "{{ \"name\": \"{}\", \"ops_per_sec\": {}, \"total_ops\": {}, \"duration_secs\": {} }}",
+            transform.name(), speed as u64, count, duration
         );
     } else {
         println!("------------------------------------------------");

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -41,17 +41,23 @@ fn benchmark_name(transform_type: &TransformType) -> String {
             format!("sha256_chain:{}:depth={}", variant_name, chain_depth)
         }
         TransformType::Bitimage {
+            path,
             passphrase,
             passphrase_wordlist,
             derive_count,
             ..
         } => format!(
-            "bitimage:passphrase_present={}:wordlist_present={}:derive_count={}",
+            "bitimage:path={}:passphrase_present={}:wordlist_present={}:derive_count={}",
+            escape_label_value(path),
             !passphrase.is_empty(),
             passphrase_wordlist.is_some(),
             derive_count
         ),
     }
+}
+
+fn escape_label_value(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
 }
 
 fn format_benchmark_json(
@@ -183,7 +189,7 @@ mod tests {
         assert_eq!(name, benchmark_name(&transform_type));
         assert_eq!(
             name,
-            "bitimage:passphrase_present=true:wordlist_present=false:derive_count=2"
+            "bitimage:path=C:\\\\keys\\\\\\\"set\\\"\\n.txt:passphrase_present=true:wordlist_present=false:derive_count=2"
         );
         assert!(!name.contains("word\"list\\seed\t"));
         assert!(!name.contains("C:\\keys\\\"set\"\n.txt"));

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -2,10 +2,84 @@
 
 use anyhow::Result;
 use rayon::prelude::*;
+use serde_json::json;
+use sha2::{Digest, Sha256};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use crate::transform::{Input, TransformType};
+
+fn benchmark_name(transform_type: &TransformType) -> String {
+    match transform_type {
+        TransformType::Direct => "direct".to_string(),
+        TransformType::Sha256 => "sha256".to_string(),
+        TransformType::DoubleSha256 => "double_sha256".to_string(),
+        TransformType::Md5 => "md5".to_string(),
+        TransformType::Milksad => "milksad".to_string(),
+        TransformType::Mt64 => "mt64".to_string(),
+        TransformType::Armory => "armory".to_string(),
+        TransformType::Multibit => "multibit".to_string(),
+        TransformType::Electrum { for_change } => {
+            if *for_change {
+                "electrum:change".to_string()
+            } else {
+                "electrum:receive".to_string()
+            }
+        }
+        TransformType::Lcg { variant, endian } => {
+            let variant_name = variant.map(|v| v.name).unwrap_or("all");
+            format!("lcg:{}:{}", variant_name, endian.as_str())
+        }
+        TransformType::Xorshift { variant } => {
+            let variant_name = variant.map(|v| v.name()).unwrap_or("all");
+            format!("xorshift:{}", variant_name)
+        }
+        TransformType::Sha256Chain {
+            variant,
+            chain_depth,
+        } => {
+            let variant_name = variant.map(|v| v.name()).unwrap_or("all");
+            format!("sha256_chain:{}:depth={}", variant_name, chain_depth)
+        }
+        TransformType::Bitimage {
+            path,
+            passphrase,
+            passphrase_wordlist,
+            derive_count,
+        } => format!(
+            "bitimage:path={}:passphrase={}:wordlist={}:derive_count={}",
+            fingerprint(path),
+            fingerprint(passphrase),
+            passphrase_wordlist
+                .as_ref()
+                .map(|path| fingerprint(&path.display().to_string()))
+                .unwrap_or_else(|| "none".to_string()),
+            derive_count
+        ),
+    }
+}
+
+fn fingerprint(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(&digest[..6])
+}
+
+fn format_benchmark_json(
+    transform_type: &TransformType,
+    speed: u64,
+    count: u64,
+    duration: f64,
+) -> String {
+    let transform_name = benchmark_name(transform_type);
+
+    json!({
+        "name": transform_name,
+        "ops_per_sec": speed,
+        "total_ops": count,
+        "duration_secs": duration,
+    })
+    .to_string()
+}
 
 /// Run standardized benchmark for a transform.
 pub fn run_benchmark(transform_type: TransformType, json: bool) -> Result<()> {
@@ -54,8 +128,8 @@ pub fn run_benchmark(transform_type: TransformType, json: bool) -> Result<()> {
 
     if json {
         println!(
-            "{{ \"name\": \"{}\", \"ops_per_sec\": {}, \"total_ops\": {}, \"duration_secs\": {} }}",
-            transform.name(), speed as u64, count, duration
+            "{}",
+            format_benchmark_json(&transform_type, speed as u64, count, duration)
         );
     } else {
         println!("------------------------------------------------");
@@ -65,4 +139,47 @@ pub fn run_benchmark(transform_type: TransformType, json: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{benchmark_name, format_benchmark_json};
+
+    use crate::lcg::{LcgEndian, GLIBC};
+    use crate::transform::TransformType;
+
+    #[test]
+    fn benchmark_json_keeps_parameterized_transform_details() {
+        let transform_type = TransformType::Lcg {
+            variant: Some(GLIBC),
+            endian: LcgEndian::Big,
+        };
+
+        let output = format_benchmark_json(&transform_type, 123, 456, 7.5);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed["name"].as_str(), Some("lcg:glibc:be"));
+    }
+
+    #[test]
+    fn benchmark_json_redacts_bitimage_secrets() {
+        let transform_type = TransformType::Bitimage {
+            path: "C:\\keys\\\"set\"\n.txt".into(),
+            passphrase: "word\"list\\seed\t".into(),
+            passphrase_wordlist: None,
+            derive_count: 2,
+        };
+
+        let output = format_benchmark_json(&transform_type, 1, 2, 3.0);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        let name = parsed["name"].as_str().unwrap();
+
+        assert_eq!(name, benchmark_name(&transform_type));
+        assert!(name.contains("bitimage:path="));
+        assert!(name.contains(":passphrase="));
+        assert!(name.contains(":wordlist=none:derive_count=2"));
+        assert!(!name.contains("word\"list\\seed\t"));
+        assert!(!name.contains("C:\\keys\\\"set\"\n.txt"));
+    }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use rayon::prelude::*;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -23,7 +22,7 @@ fn benchmark_name(transform_type: &TransformType) -> String {
             if *for_change {
                 "electrum:change".to_string()
             } else {
-                "electrum:receive".to_string()
+                "electrum".to_string()
             }
         }
         TransformType::Lcg { variant, endian } => {
@@ -42,26 +41,17 @@ fn benchmark_name(transform_type: &TransformType) -> String {
             format!("sha256_chain:{}:depth={}", variant_name, chain_depth)
         }
         TransformType::Bitimage {
-            path,
             passphrase,
             passphrase_wordlist,
             derive_count,
+            ..
         } => format!(
-            "bitimage:path={}:passphrase={}:wordlist={}:derive_count={}",
-            fingerprint(path),
-            fingerprint(passphrase),
-            passphrase_wordlist
-                .as_ref()
-                .map(|path| fingerprint(&path.display().to_string()))
-                .unwrap_or_else(|| "none".to_string()),
+            "bitimage:passphrase_present={}:wordlist_present={}:derive_count={}",
+            !passphrase.is_empty(),
+            passphrase_wordlist.is_some(),
             derive_count
         ),
     }
-}
-
-fn fingerprint(value: &str) -> String {
-    let digest = Sha256::digest(value.as_bytes());
-    hex::encode(&digest[..6])
 }
 
 fn format_benchmark_json(
@@ -143,26 +133,40 @@ pub fn run_benchmark(transform_type: TransformType, json: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use super::{benchmark_name, format_benchmark_json};
 
     use crate::lcg::{LcgEndian, GLIBC};
     use crate::transform::TransformType;
 
     #[test]
-    fn benchmark_json_keeps_parameterized_transform_details() {
+    fn benchmark_json_keeps_parameterized_transform_details() -> Result<()> {
         let transform_type = TransformType::Lcg {
             variant: Some(GLIBC),
             endian: LcgEndian::Big,
         };
 
         let output = format_benchmark_json(&transform_type, 123, 456, 7.5);
-        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output)?;
 
         assert_eq!(parsed["name"].as_str(), Some("lcg:glibc:be"));
+        Ok(())
     }
 
     #[test]
-    fn benchmark_json_redacts_bitimage_secrets() {
+    fn benchmark_json_uses_canonical_electrum_names() {
+        let receive = TransformType::Electrum { for_change: false };
+        let change = TransformType::Electrum { for_change: true };
+
+        assert_eq!(benchmark_name(&receive), "electrum");
+        assert_eq!(benchmark_name(&change), "electrum:change");
+        assert!(benchmark_name(&receive).parse::<TransformType>().is_ok());
+        assert!(benchmark_name(&change).parse::<TransformType>().is_ok());
+    }
+
+    #[test]
+    fn benchmark_json_redacts_bitimage_secrets() -> Result<()> {
         let transform_type = TransformType::Bitimage {
             path: "C:\\keys\\\"set\"\n.txt".into(),
             passphrase: "word\"list\\seed\t".into(),
@@ -171,15 +175,18 @@ mod tests {
         };
 
         let output = format_benchmark_json(&transform_type, 1, 2, 3.0);
-        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-
-        let name = parsed["name"].as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output)?;
+        let name = parsed["name"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("missing benchmark name"))?;
 
         assert_eq!(name, benchmark_name(&transform_type));
-        assert!(name.contains("bitimage:path="));
-        assert!(name.contains(":passphrase="));
-        assert!(name.contains(":wordlist=none:derive_count=2"));
+        assert_eq!(
+            name,
+            "bitimage:passphrase_present=true:wordlist_present=false:derive_count=2"
+        );
         assert!(!name.contains("word\"list\\seed\t"));
         assert!(!name.contains("C:\\keys\\\"set\"\n.txt"));
+        Ok(())
     }
 }


### PR DESCRIPTION
Rust's `Debug` output was ending up inside the benchmark JSON name field, which broke parsing for quoted values. Replacing it with `transform.name()` fixed the escaping, but cubic found that it also collapsed parameterized transforms into the same label.

The benchmark payload is now serialized with `serde_json` and uses a benchmark-specific name formatter. Parameterized transforms keep the config that matters for benchmarking, and bitimage paths or passphrases are hashed so the JSON output stays parseable without leaking raw secrets.
