### PR TITLE
refactor(analyze): use fmt::Write instead of push_str(&format!(...))

### DIFF
--- a/src/analyze/output.rs
+++ b/src/analyze/output.rs
@@ -1,24 +1,24 @@
+use std::fmt::Write;
+
 use super::{AnalysisResult, KeyMetadata};
 
 pub fn format_results(metadata: &KeyMetadata, results: &[AnalysisResult]) -> String {
     let mut output = String::new();
 
-    output.push_str(&format!("Private Key: {}\n", metadata.hex));
-    output.push_str(&format!("Bit Length:  {}\n", metadata.bit_length));
-    output.push_str(&format!("Hamming Weight: {}\n", metadata.hamming_weight));
+    let _ = writeln!(output, "Private Key: {}", metadata.hex);
+    let _ = writeln!(output, "Bit Length:  {}", metadata.bit_length);
+    let _ = writeln!(output, "Hamming Weight: {}", metadata.hamming_weight);
     output.push_str("---\n");
     output.push_str("Analysis:\n");
 
     for result in results {
         let symbol = result.status.symbol();
         let details = result.details.as_deref().unwrap_or("");
-        output.push_str(&format!(
-            "  {} {}: {} {}\n",
-            symbol,
-            result.analyzer,
-            result.status.as_str().to_uppercase(),
-            if details.is_empty() { String::new() } else { format!("({})", details) }
-        ));
+        if details.is_empty() {
+            let _ = writeln!(output, "  {} {}: {}", symbol, result.analyzer, result.status.as_str().to_uppercase());
+        } else {
+            let _ = writeln!(output, "  {} {}: {} ({})", symbol, result.analyzer, result.status.as_str().to_uppercase(), details);
+        }
     }
 
     output
@@ -68,7 +68,7 @@ fn escape_json(s: &str) -> String {
             '\r' => result.push_str("\\r"),
             '\t' => result.push_str("\\t"),
             c if c.is_control() => {
-                result.push_str(&format!("\\u{:04x}", c as u32));
+                let _ = write!(result, "\\u{:04x}", c as u32);
             }
             c => result.push(c),
         }

--- a/src/analyze/output.rs
+++ b/src/analyze/output.rs
@@ -105,6 +105,29 @@ mod tests {
     }
 
     #[test]
+    fn test_format_results_no_details() {
+        let metadata = KeyMetadata {
+            hex: "def456".to_string(),
+            bit_length: 128,
+            hamming_weight: 64,
+            leading_zeros: 0,
+        };
+
+        let results = vec![
+            AnalysisResult {
+                analyzer: "test",
+                status: AnalysisStatus::NotFound,
+                details: None,
+            },
+        ];
+
+        let output = format_results(&metadata, &results);
+        assert!(output.contains("NOT_FOUND\n"));
+        assert!(!output.contains("()"));
+        assert!(!output.contains("NOT_FOUND \n"));
+    }
+
+    #[test]
     fn test_format_json() {
         let metadata = KeyMetadata {
             hex: "abc123".to_string(),


### PR DESCRIPTION
`format_results` and `escape_json` were building strings with `push_str(&format!(...))` which allocates an intermediate String per call. `writeln!` via `std::fmt::Write` writes directly into the target buffer. Also fixes a trailing space on lines where analysis details are empty.