### PR TITLE
feat(analyze): accept multiple keys in analyze subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -254,8 +254,13 @@ enum Command {
 
     /// Analyze a private key for potential vulnerable origins
     Analyze {
-        /// Private key (hex, WIF, or decimal)
-        key: String,
+        /// Private key(s) (hex, WIF, or decimal)
+        #[arg(num_args = 1..)]
+        key: Vec<String>,
+
+        /// File with keys to analyze (one per line, same formats as positional)
+        #[arg(long, value_name = "FILE")]
+        key_file: Option<PathBuf>,
 
         /// Skip brute-force checks (faster, heuristics only)
         #[arg(long)]
@@ -424,6 +429,7 @@ fn main() -> Result<()> {
 
         Command::Analyze {
             key,
+            key_file,
             fast,
             mask,
             cascade,
@@ -441,8 +447,24 @@ fn main() -> Result<()> {
             #[cfg(not(feature = "gpu"))]
             let use_gpu = false;
 
+            let mut keys = key;
+            if let Some(file_path) = key_file {
+                let content = std::fs::read_to_string(&file_path)
+                    .map_err(|e| anyhow::anyhow!("Failed to read key file {}: {}", file_path.display(), e))?;
+                for line in content.lines() {
+                    let line = line.trim();
+                    if !line.is_empty() && !line.starts_with('#') {
+                        keys.push(line.to_string());
+                    }
+                }
+            }
+
+            if keys.is_empty() {
+                anyhow::bail!("No keys provided. Pass keys as arguments or use --key-file");
+            }
+
             run_analyze(
-                &key,
+                &keys,
                 fast,
                 mask,
                 cascade,
@@ -1186,7 +1208,7 @@ fn resolve_cascade(input: &str) -> Result<Option<Vec<(u8, u64)>>> {
 // ---------------------------------------------------------------------------
 
 fn run_analyze(
-    key_input: &str,
+    key_inputs: &[String],
     fast: bool,
     mask_bits: Option<u8>,
     cascade_input: Option<String>,
@@ -1238,74 +1260,6 @@ fn run_analyze(
             if let Some(bits) = ctx.mask_bits {
                 eprintln!("Auto-mask: {} bits", bits);
             }
-        }
-    }
-
-    let key = parse_private_key(key_input)?;
-    let metadata = KeyMetadata::from_key(&key);
-
-    if let Some(ref verify_ref) = verify_input {
-        match vuke::provider::verify_key(&key, verify_ref)? {
-            Some(report) => {
-                if json_output {
-                    let matches_json: Vec<String> = report
-                        .matches
-                        .iter()
-                        .map(|m| {
-                            format!(
-                                r#"{{"puzzle_id":"{}","address":"{}","address_type":"{}","status":"{}","prize":{}}}"#,
-                                m.puzzle_id,
-                                m.address,
-                                m.address_type,
-                                m.status,
-                                m.prize.map_or("null".to_string(), |p| p.to_string())
-                            )
-                        })
-                        .collect();
-                    println!(
-                        r#"{{"key":"{}","total_checked":{},"matches":[{}]}}"#,
-                        key_input,
-                        report.total_checked,
-                        matches_json.join(",")
-                    );
-                } else {
-                    println!("Verification Report");
-                    println!("---");
-                    println!("Key: {}", key_input);
-                    println!("Checked: {} puzzles", report.total_checked);
-                    println!();
-
-                    if report.matches.is_empty() {
-                        println!("No matches found.");
-                    } else {
-                        println!("Matches:");
-                        for m in &report.matches {
-                            println!("  {} ({})", m.puzzle_id, m.status);
-                            println!("    Address: {} ({})", m.address, m.address_type);
-                            if let Some(prize) = m.prize {
-                                println!("    Prize: {} BTC", prize);
-                            }
-                        }
-                    }
-                }
-                return Ok(());
-            }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "Invalid verify provider reference: {}",
-                    verify_ref
-                ));
-            }
-        }
-    }
-
-    if let Some(bits) = mask_bits {
-        let key_bits = vuke::analyze::calculate_bit_length(&key);
-        if key_bits > bits as u16 {
-            eprintln!(
-                "Warning: key has {} bits but mask is {} bits. Key will be treated as already masked.",
-                key_bits, bits
-            );
         }
     }
 
@@ -1369,47 +1323,134 @@ fn run_analyze(
     #[cfg(not(feature = "gpu"))]
     let _ = use_gpu; // Suppress unused warning
 
-    let mut results = Vec::new();
+    let multi = key_inputs.len() > 1;
+    let mut json_entries = Vec::new();
 
-    for analyzer in &analyzers {
-        let progress = if analyzer.is_brute_force() && !json_output {
-            let pb = ProgressBar::new(0);
-            pb.set_style(vuke::default_progress_style());
-            Some(pb)
-        } else {
-            None
-        };
+    for (i, key_input) in key_inputs.iter().enumerate() {
+        let key = parse_private_key(key_input)?;
+        let metadata = KeyMetadata::from_key(&key);
 
-        // Try GPU first if available and supported
-        #[cfg(feature = "gpu")]
-        let result = if let Some(ref ctx) = gpu_ctx {
-            if analyzer.supports_gpu() {
-                match analyzer.analyze_gpu(ctx, &key, &config, progress.as_ref()) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        if !json_output {
-                            eprintln!("GPU error ({}), falling back to CPU", e);
+        if let Some(ref verify_ref) = verify_input {
+            match vuke::provider::verify_key(&key, verify_ref)? {
+                Some(report) => {
+                    if json_output {
+                        let matches_json: Vec<String> = report
+                            .matches
+                            .iter()
+                            .map(|m| {
+                                format!(
+                                    r#"{{"puzzle_id":"{}","address":"{}","address_type":"{}","status":"{}","prize":{}}}"#,
+                                    m.puzzle_id,
+                                    m.address,
+                                    m.address_type,
+                                    m.status,
+                                    m.prize.map_or("null".to_string(), |p| p.to_string())
+                                )
+                            })
+                            .collect();
+                        json_entries.push(format!(
+                            r#"{{"key":"{}","total_checked":{},"matches":[{}]}}"#,
+                            key_input,
+                            report.total_checked,
+                            matches_json.join(",")
+                        ));
+                    } else {
+                        if multi && i > 0 {
+                            println!();
                         }
-                        analyzer.analyze(&key, &config, progress.as_ref())
+                        println!("Verification Report");
+                        println!("---");
+                        println!("Key: {}", key_input);
+                        println!("Checked: {} puzzles", report.total_checked);
+                        println!();
+
+                        if report.matches.is_empty() {
+                            println!("No matches found.");
+                        } else {
+                            println!("Matches:");
+                            for m in &report.matches {
+                                println!("  {} ({})", m.puzzle_id, m.status);
+                                println!("    Address: {} ({})", m.address, m.address_type);
+                                if let Some(prize) = m.prize {
+                                    println!("    Prize: {} BTC", prize);
+                                }
+                            }
+                        }
                     }
+                    continue;
+                }
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "Invalid verify provider reference: {}",
+                        verify_ref
+                    ));
+                }
+            }
+        }
+
+        if let Some(bits) = mask_bits {
+            let key_bits = vuke::analyze::calculate_bit_length(&key);
+            if key_bits > bits as u16 {
+                eprintln!(
+                    "Warning: key has {} bits but mask is {} bits. Key will be treated as already masked.",
+                    key_bits, bits
+                );
+            }
+        }
+
+        let mut results = Vec::new();
+
+        for analyzer in &analyzers {
+            let progress = if analyzer.is_brute_force() && !json_output {
+                let pb = ProgressBar::new(0);
+                pb.set_style(vuke::default_progress_style());
+                Some(pb)
+            } else {
+                None
+            };
+
+            // Try GPU first if available and supported
+            #[cfg(feature = "gpu")]
+            let result = if let Some(ref ctx) = gpu_ctx {
+                if analyzer.supports_gpu() {
+                    match analyzer.analyze_gpu(ctx, &key, &config, progress.as_ref()) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            if !json_output {
+                                eprintln!("GPU error ({}), falling back to CPU", e);
+                            }
+                            analyzer.analyze(&key, &config, progress.as_ref())
+                        }
+                    }
+                } else {
+                    analyzer.analyze(&key, &config, progress.as_ref())
                 }
             } else {
                 analyzer.analyze(&key, &config, progress.as_ref())
-            }
+            };
+
+            #[cfg(not(feature = "gpu"))]
+            let result = analyzer.analyze(&key, &config, progress.as_ref());
+
+            results.push(result);
+        }
+
+        if json_output {
+            json_entries.push(format_results_json(&metadata, &results));
         } else {
-            analyzer.analyze(&key, &config, progress.as_ref())
-        };
-
-        #[cfg(not(feature = "gpu"))]
-        let result = analyzer.analyze(&key, &config, progress.as_ref());
-
-        results.push(result);
+            if multi && i > 0 {
+                println!();
+            }
+            print!("{}", format_results(&metadata, &results));
+        }
     }
 
     if json_output {
-        println!("{}", format_results_json(&metadata, &results));
-    } else {
-        print!("{}", format_results(&metadata, &results));
+        if multi {
+            println!("[{}]", json_entries.join(",\n"));
+        } else if let Some(entry) = json_entries.into_iter().next() {
+            println!("{}", entry);
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,6 @@ enum Command {
     /// Analyze a private key for potential vulnerable origins
     Analyze {
         /// Private key(s) (hex, WIF, or decimal)
-        #[arg(num_args = 1..)]
         key: Vec<String>,
 
         /// File with keys to analyze (one per line, same formats as positional)
@@ -1325,9 +1324,25 @@ fn run_analyze(
 
     let multi = key_inputs.len() > 1;
     let mut json_entries = Vec::new();
+    let mut had_error = false;
 
     for (i, key_input) in key_inputs.iter().enumerate() {
-        let key = parse_private_key(key_input)?;
+        let key = match parse_private_key(key_input) {
+            Ok(k) => k,
+            Err(e) => {
+                if json_output {
+                    json_entries.push(format!(
+                        r#"{{"key":"{}","error":"{}"}}"#,
+                        key_input,
+                        e.to_string().replace('"', "\\\"")
+                    ));
+                } else {
+                    eprintln!("Error parsing key '{}': {}", key_input, e);
+                }
+                had_error = true;
+                continue;
+            }
+        };
         let metadata = KeyMetadata::from_key(&key);
 
         if let Some(ref verify_ref) = verify_input {
@@ -1451,6 +1466,10 @@ fn run_analyze(
         } else if let Some(entry) = json_entries.into_iter().next() {
             println!("{}", entry);
         }
+    }
+
+    if had_error && multi {
+        anyhow::bail!("Some keys failed to parse");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1331,10 +1331,15 @@ fn run_analyze(
             Ok(k) => k,
             Err(e) => {
                 if json_output {
+                    let err_msg = e.to_string()
+                        .replace('\\', "\\\\")
+                        .replace('"', "\\\"")
+                        .replace('\n', "\\n")
+                        .replace('\r', "\\r")
+                        .replace('\t', "\\t");
                     json_entries.push(format!(
                         r#"{{"key":"{}","error":"{}"}}"#,
-                        key_input,
-                        e.to_string().replace('"', "\\\"")
+                        key_input, err_msg
                     ));
                 } else {
                     eprintln!("Error parsing key '{}': {}", key_input, e);
@@ -1468,7 +1473,7 @@ fn run_analyze(
         }
     }
 
-    if had_error && multi {
+    if had_error {
         anyhow::bail!("Some keys failed to parse");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1325,8 +1325,9 @@ fn run_analyze(
     let multi = key_inputs.len() > 1;
     let mut json_entries = Vec::new();
     let mut had_error = false;
+    let mut printed_count = 0usize;
 
-    for (i, key_input) in key_inputs.iter().enumerate() {
+    for key_input in key_inputs {
         let key = match parse_private_key(key_input) {
             Ok(k) => k,
             Err(e) => {
@@ -1376,7 +1377,7 @@ fn run_analyze(
                             matches_json.join(",")
                         ));
                     } else {
-                        if multi && i > 0 {
+                        if multi && printed_count > 0 {
                             println!();
                         }
                         println!("Verification Report");
@@ -1397,6 +1398,7 @@ fn run_analyze(
                                 }
                             }
                         }
+                        printed_count += 1;
                     }
                     continue;
                 }
@@ -1459,10 +1461,11 @@ fn run_analyze(
         if json_output {
             json_entries.push(format_results_json(&metadata, &results));
         } else {
-            if multi && i > 0 {
+            if multi && printed_count > 0 {
                 println!();
             }
             print!("{}", format_results(&metadata, &results));
+            printed_count += 1;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1331,15 +1331,16 @@ fn run_analyze(
             Ok(k) => k,
             Err(e) => {
                 if json_output {
-                    let err_msg = e.to_string()
-                        .replace('\\', "\\\\")
-                        .replace('"', "\\\"")
-                        .replace('\n', "\\n")
-                        .replace('\r', "\\r")
-                        .replace('\t', "\\t");
+                    let escape = |s: &str| -> String {
+                        s.replace('\\', "\\\\")
+                            .replace('"', "\\\"")
+                            .replace('\n', "\\n")
+                            .replace('\r', "\\r")
+                            .replace('\t', "\\t")
+                    };
                     json_entries.push(format!(
                         r#"{{"key":"{}","error":"{}"}}"#,
-                        key_input, err_msg
+                        escape(key_input), escape(&e.to_string())
                     ));
                 } else {
                     eprintln!("Error parsing key '{}': {}", key_input, e);


### PR DESCRIPTION
`vuke analyze` only took a single key. When investigating a cluster of related keys you had to run the command once per key, which gets tedious fast.

Now it accepts multiple positional args and a `--key-file` flag:

```
vuke analyze 0x1a2b 0x3c4d --analyzer milksad
vuke analyze --key-file suspicious_keys.txt --analyzer lcg
```

Each key runs through the selected analyzers independently. Human output separates keys with blank lines, JSON wraps results in an array when there's more than one key (single key still returns a plain object for backwards compat).

`--key-file` reads one key per line, same formats `parse_private_key` already handles (hex, WIF, decimal). Lines starting with `#` are skipped.

Closes #84